### PR TITLE
Add redis backend to the counter sink

### DIFF
--- a/counter-sink/README.adoc
+++ b/counter-sink/README.adoc
@@ -1,0 +1,36 @@
+= Spring Cloud Stream Counter Sink
+
+A *Spring Cloud Stream* module that simply counts the number of messages it receives,
+optionally storing counts in a separate backend such as redis.
+== Requirements
+
+To run this module, you will need to have installed:
+
+* Java 7 or Above
+
+This example requires Redis to be running on localhost.
+
+== Code Tour
+
+CounterSinkApplication:: the Spring Boot Main Application
+CounterSink:: the actual module code that interacts with message channels
+CounterSinkProperties:: defines the configuration properties that are available to the Filter Processor
+  * name: the name of the counter to increment
+  * nameExpression: a SpEL expression used to derive the name of the counter to increment
+  * backend: where to store counters. This project's code supports `memory` and `redis`
+
+
+## Building with Maven
+
+Build the module by executing:
+
+```
+$> mvn package
+```
+
+## Running the Application
+
+To start the module execute the following:
+```
+$> java -jar target/counter-sink-${version}-exec.jar
+```

--- a/counter-sink/README.adoc
+++ b/counter-sink/README.adoc
@@ -1,14 +1,14 @@
 = Spring Cloud Stream Counter Sink
 
 A *Spring Cloud Stream* module that simply counts the number of messages it receives,
-optionally storing counts in a separate backend such as redis.
+optionally storing counts in a separate store such as redis.
 == Requirements
 
 To run this module, you will need to have installed:
 
 * Java 7 or Above
-
-This example requires Redis to be running on localhost.
+* One of the supported Spring Cloud Stream binders (_e.g._ redis, rabbit, _etc._)
+* Redis to store counters (optional)
 
 == Code Tour
 
@@ -17,7 +17,7 @@ CounterSink:: the actual module code that interacts with message channels
 CounterSinkProperties:: defines the configuration properties that are available to the Filter Processor
   * name: the name of the counter to increment
   * nameExpression: a SpEL expression used to derive the name of the counter to increment
-  * backend: where to store counters. This project's code supports `memory` and `redis`
+  * store: where to store counters. This project's code supports `memory` and `redis`
 
 
 ## Building with Maven

--- a/counter-sink/src/main/java/org/springframework/cloud/stream/module/metrics/CounterSinkConfiguration.java
+++ b/counter-sink/src/main/java/org/springframework/cloud/stream/module/metrics/CounterSinkConfiguration.java
@@ -15,19 +15,14 @@
  */
 package org.springframework.cloud.stream.module.metrics;
 
+import javax.annotation.PostConstruct;
+
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.actuate.metrics.CounterService;
-import org.springframework.boot.actuate.metrics.repository.redis.RedisMetricRepository;
-import org.springframework.boot.actuate.metrics.writer.DefaultCounterService;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.integration.context.IntegrationContextUtils;
-
-import javax.annotation.PostConstruct;
 
 /**
  * @author Mark Pollack
@@ -40,17 +35,6 @@ public class CounterSinkConfiguration {
 	private BeanFactory beanFactory;
 
     private EvaluationContext evaluationContext;
-
-    @Bean
-    public CounterService counterService(RedisMetricRepository redisMetricRepository) {
-        return new DefaultCounterService(redisMetricRepository);
-    }
-
-    @Bean
-    public RedisMetricRepository redisMetricRepository(RedisConnectionFactory redisConnectionFactory) {
-        return new RedisMetricRepository(redisConnectionFactory);
-    }
-
 
     public EvaluationContext evaluationContext() {
         return evaluationContext;

--- a/counter-sink/src/main/java/org/springframework/cloud/stream/module/metrics/CounterSinkProperties.java
+++ b/counter-sink/src/main/java/org/springframework/cloud/stream/module/metrics/CounterSinkProperties.java
@@ -42,6 +42,19 @@ public class CounterSinkProperties {
 	 */
 	private String nameExpression;
 
+	/**
+	 * The name of a backend used to store the counter.
+	 */
+	// Stored as a String to allow forward extension of the module
+	private String backend = "memory";
+
+	public String getBackend() {
+		return backend;
+	}
+
+	public void setBackend(String backend) {
+		this.backend = backend;
+	}
 
 	public String getName() {
 		return name;

--- a/counter-sink/src/main/java/org/springframework/cloud/stream/module/metrics/CounterSinkProperties.java
+++ b/counter-sink/src/main/java/org/springframework/cloud/stream/module/metrics/CounterSinkProperties.java
@@ -43,17 +43,17 @@ public class CounterSinkProperties {
 	private String nameExpression;
 
 	/**
-	 * The name of a backend used to store the counter.
+	 * The name of a store used to store the counter.
 	 */
 	// Stored as a String to allow forward extension of the module
-	private String backend = "memory";
+	private String store = "memory";
 
-	public String getBackend() {
-		return backend;
+	public String getStore() {
+		return store;
 	}
 
-	public void setBackend(String backend) {
-		this.backend = backend;
+	public void setStore(String store) {
+		this.store = store;
 	}
 
 	public String getName() {

--- a/counter-sink/src/main/java/org/springframework/cloud/stream/module/metrics/CounterSinkRedisBackendConfiguration.java
+++ b/counter-sink/src/main/java/org/springframework/cloud/stream/module/metrics/CounterSinkRedisBackendConfiguration.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2015 the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.module.metrics;
+
+import org.springframework.boot.actuate.autoconfigure.ExportMetricWriter;
+import org.springframework.boot.actuate.metrics.repository.redis.RedisMetricRepository;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+
+/**
+ * Used to configure the connection and offloading of counters to redis in case it is used as
+ * a backend.
+ *
+ * @author Eric Bottard
+ * @see CounterSinkProperties#getBackend()
+ */
+@Configuration
+@ConditionalOnProperty(value="backend", havingValue = "redis")
+public class CounterSinkRedisBackendConfiguration {
+
+	@Bean
+	@ExportMetricWriter
+	public RedisMetricRepository redisMetricRepository(RedisConnectionFactory connectionFactory) {
+		return new RedisMetricRepository(connectionFactory);
+	}
+}

--- a/counter-sink/src/main/java/org/springframework/cloud/stream/module/metrics/CounterSinkRedisBackendConfiguration.java
+++ b/counter-sink/src/main/java/org/springframework/cloud/stream/module/metrics/CounterSinkRedisBackendConfiguration.java
@@ -18,20 +18,19 @@ package org.springframework.cloud.stream.module.metrics;
 import org.springframework.boot.actuate.autoconfigure.ExportMetricWriter;
 import org.springframework.boot.actuate.metrics.repository.redis.RedisMetricRepository;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 
 /**
  * Used to configure the connection and offloading of counters to redis in case it is used as
- * a backend.
+ * a store.
  *
  * @author Eric Bottard
- * @see CounterSinkProperties#getBackend()
+ * @see CounterSinkProperties#getStore()
  */
 @Configuration
-@ConditionalOnProperty(value="backend", havingValue = "redis")
+@ConditionalOnProperty(value="store", havingValue = "redis")
 public class CounterSinkRedisBackendConfiguration {
 
 	@Bean

--- a/counter-sink/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/counter-sink/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,22 @@
+{
+  "hints": [
+    {
+      "name": "backend",
+      "values": [
+        {
+          "value": "memory",
+          "description": "store the counter in memory only"
+        },
+        {
+          "value": "redis",
+          "description": "flush the counter value to redis periodically"
+        }
+      ],
+      "providers": [
+        {
+          "name": "any"
+        }
+      ]
+    }
+  ]
+}

--- a/counter-sink/src/test/java/org/springframework/cloud/stream/module/metrics/CounterSinkSimpleNameTests.java
+++ b/counter-sink/src/test/java/org/springframework/cloud/stream/module/metrics/CounterSinkSimpleNameTests.java
@@ -20,6 +20,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.metrics.repository.MetricRepository;
 import org.springframework.boot.actuate.metrics.repository.redis.RedisMetricRepository;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.boot.test.WebIntegrationTest;
@@ -38,7 +39,7 @@ import static org.junit.Assert.assertNotNull;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = CounterSinkApplication.class)
-@WebIntegrationTest({"server.port:0","name:simpleCounter"})
+@WebIntegrationTest({"server.port:0","name:simpleCounter","store:redis"})
 @DirtiesContext
 public class CounterSinkSimpleNameTests {
 
@@ -49,7 +50,7 @@ public class CounterSinkSimpleNameTests {
     private Sink sink;
 
     @Autowired
-    private RedisMetricRepository redisMetricRepository;
+    private MetricRepository redisMetricRepository;
 
     @Before
     public void init() {
@@ -62,10 +63,11 @@ public class CounterSinkSimpleNameTests {
     }
 
     @Test
-    public void testIncrement() {
+    public void testIncrement() throws InterruptedException {
         assertNotNull(this.sink.input());
         Message<String> message = MessageBuilder.withPayload("Hi").build();
         sink.input().send(message);
+        Thread.sleep(5500);
         //Note:  If the name of the counter does not start with 'counter' or 'metric' the 'counter.' prefix is added
         //       by the DefaultCounterService
         assertEquals(1, this.redisMetricRepository.findOne("counter.simpleCounter").getValue().longValue());


### PR DESCRIPTION
Currently uses the binder redis connection until we figure out 
https://github.com/spring-cloud/spring-cloud-stream/pull/68
