### PR TITLE
Use Java 1.7 for stream modules

### DIFF
--- a/counter-sink/pom.xml
+++ b/counter-sink/pom.xml
@@ -17,7 +17,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<start-class>org.springframework.cloud.stream.module.metrics.CounterSinkApplication</start-class>
-		<java.version>1.8</java.version>
+		<java.version>1.7</java.version>
 	</properties>
 
 	<dependencies>

--- a/log-sink/pom.xml
+++ b/log-sink/pom.xml
@@ -17,7 +17,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<start-class>org.springframework.cloud.stream.module.log.LogSinkApplication</start-class>
-		<java.version>1.8</java.version>
+		<java.version>1.7</java.version>
 	</properties>
 
 	<dependencies>

--- a/time-source/pom.xml
+++ b/time-source/pom.xml
@@ -17,7 +17,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<start-class>org.springframework.cloud.stream.module.time.TimeSourceApplication</start-class>
-		<java.version>1.8</java.version>
+		<java.version>1.7</java.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
- this will allow us to deploy them to more systems including YARN clusters running on JDK7
