### PR TITLE
Stream modules enhancements

### DIFF
--- a/counter-sink/pom.xml
+++ b/counter-sink/pom.xml
@@ -15,24 +15,6 @@
 	</parent>
 
 	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<start-class>org.springframework.cloud.stream.module.metrics.CounterSinkApplication</start-class>
-		<java.version>1.7</java.version>
 	</properties>
-
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-redis</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
 </project>

--- a/counter-sink/src/main/resources/application.yml
+++ b/counter-sink/src/main/resources/application.yml
@@ -5,4 +5,4 @@ spring:
   cloud:
     stream:
       bindings:
-        input: counter
+        input: ${remote.name:application:${server.port}}

--- a/log-sink/pom.xml
+++ b/log-sink/pom.xml
@@ -15,20 +15,6 @@
 	</parent>
 
 	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<start-class>org.springframework.cloud.stream.module.log.LogSinkApplication</start-class>
-		<java.version>1.7</java.version>
 	</properties>
-
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
 </project>

--- a/log-sink/src/main/java/org/springframework/cloud/stream/module/log/LogSinkApplication.java
+++ b/log-sink/src/main/java/org/springframework/cloud/stream/module/log/LogSinkApplication.java
@@ -18,10 +18,8 @@ package org.springframework.cloud.stream.module.log;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication
-@ComponentScan(basePackageClasses=LogSink.class)
 public class LogSinkApplication {
 
 	public static void main(String[] args) throws InterruptedException {

--- a/log-sink/src/main/resources/application.yml
+++ b/log-sink/src/main/resources/application.yml
@@ -4,4 +4,4 @@ spring:
   cloud:
     stream:
       bindings:
-        input: ticktock
+        input: ${remote.name:application:${server.port}}

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,10 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-stream</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-stream-binder-redis</artifactId>
 		</dependency>
 		<dependency>
@@ -52,6 +56,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-configuration-processor</artifactId>
 			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 </project>

--- a/time-source/pom.xml
+++ b/time-source/pom.xml
@@ -15,20 +15,6 @@
 	</parent>
 
 	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<start-class>org.springframework.cloud.stream.module.time.TimeSourceApplication</start-class>
-		<java.version>1.7</java.version>
 	</properties>
-
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
 </project>

--- a/time-source/src/main/java/org/springframework/cloud/stream/module/time/TimeSourceApplication.java
+++ b/time-source/src/main/java/org/springframework/cloud/stream/module/time/TimeSourceApplication.java
@@ -18,13 +18,11 @@ package org.springframework.cloud.stream.module.time;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication
-@ComponentScan(basePackageClasses=TimeSource.class)
 public class TimeSourceApplication {
 
-	public static void main(String[] args) throws InterruptedException {
+	public static void main(String[] args) {
 		SpringApplication.run(TimeSourceApplication.class, args);
 	}
 

--- a/time-source/src/main/resources/application.yml
+++ b/time-source/src/main/resources/application.yml
@@ -6,4 +6,4 @@ spring:
   cloud:
     stream:
       bindings:
-        output: ticktock
+        output: ${remote.name:application:${server.port}}


### PR DESCRIPTION
- Move few more common dependencies to parent POM
  - Move `spring-cloud-stream` and `spring-boot-starter-test` into parent pom.xml.
- Add `remote.name` as a property in application.yml for `spring.cloud.stream.bindings.input/output`
  - This will let the modules connecting to each other using a common `remote.name`
- Misc cleanup
