### PR TITLE
Add cloud connector dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>1.7</java.version>
+		<spring-cloud-lattice.version>1.1.0.BUILD-SNAPSHOT</spring-cloud-lattice.version>
 	</properties>
 
 	<modules>
@@ -99,12 +100,32 @@
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
-	<!--TODO: Move transport related dependencies here pending https://jira.spring.io/browse/XD-3337  -->
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-stream</artifactId>
 		</dependency>
+		<!-- Cloud connector dependencies -->
+		<!-- Lattice connector dependency to create services info from lattice -->
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-lattice-connector</artifactId>
+			<version>${spring-cloud-lattice.version}</version>
+			<optional>true</optional>
+		</dependency>
+		<!-- CF connector dependency to create services info from CF -->
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-cloudfoundry-connector</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<!-- dependency to connect to detected cloud services -->
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-spring-service-connector</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<!--TODO: Move transport related dependencies here pending https://jira.spring.io/browse/XD-3337  -->
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-stream-binder-redis</artifactId>


### PR DESCRIPTION
- Add `lattice-connector`, `cf-connector` and `spring-service-connector`
  dependencies to stream modules so that these dependencies need not be added
  into `spring-cloud-stream` or `spring-cloud-stream-binder`.
- This will also let the module developer deploy the self contained modules
  into local, lattice and cf environment without admin.
