### PR TITLE
Add lattice-core dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,13 @@
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-stream</artifactId>
 		</dependency>
+		<!-- Lattice core dependency that activates cloud,lattice profiles when running on Lattice -->
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-lattice-core</artifactId>
+			<version>${spring-cloud-lattice.version}</version>
+			<optional>true</optional>
+		</dependency>
 		<!-- Cloud connector dependencies -->
 		<!-- Lattice connector dependency to create services info from lattice -->
 		<dependency>


### PR DESCRIPTION
- This dependency activates `cloud` and `lattice` profiles when running on Lattice.
- This helps avoiding the need to explicitly activating these profiles when running on Lattice.
