### PR TITLE
Add Twitterstream module

### DIFF
--- a/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/twitter/TwitterCredentials.java
+++ b/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/twitter/TwitterCredentials.java
@@ -25,12 +25,24 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 //todo: Move these properties into spring-boot's TwitterProperties prefixed with: `spring.social.twitter`
 public class TwitterCredentials {
 
+	/**
+	 * Consumer key
+	 */
 	private String consumerKey;
 
+	/**
+	 * Consumer secret
+	 */
 	private String consumerSecret;
 
+	/**
+	 * Access token
+	 */
 	private String accessToken;
 
+	/**
+	 * Access token secret
+	 */
 	private String accessTokenSecret;
 
 	public String getConsumerKey() {

--- a/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/twitter/TwitterCredentials.java
+++ b/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/twitter/TwitterCredentials.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2015 the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.stream.module.twitter;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Twitter credentials.
+ *
+ * @author Ilayaperumal Gopinathan
+ */
+@ConfigurationProperties
+//todo: Move these properties into spring-boot's TwitterProperties prefixed with: `spring.social.twitter`
+public class TwitterCredentials {
+
+	private String consumerKey;
+
+	private String consumerSecret;
+
+	private String accessToken;
+
+	private String accessTokenSecret;
+
+	public String getConsumerKey() {
+		return this.consumerKey;
+	}
+
+	public void setConsumerKey(String consumerKey) {
+		this.consumerKey = consumerKey;
+	}
+
+	public String getConsumerSecret() {
+		return this.consumerSecret;
+	}
+
+	public void setConsumerSecret(String consumerSecret) {
+		this.consumerSecret = consumerSecret;
+	}
+
+	public String getAccessToken() {
+		return this.accessToken;
+	}
+
+	public void setAccessToken(String accessToken) {
+		this.accessToken = accessToken;
+	}
+
+	public String getAccessTokenSecret() {
+		return this.accessTokenSecret;
+	}
+
+	public void setAccessTokenSecret(String accessTokenSecret) {
+		this.accessTokenSecret = accessTokenSecret;
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
 		<module>ftp-source</module>
 		<module>http-source</module>
 		<module>time-source</module>
+		<module>twitterstream-source</module>
 		<!-- processors in alphabetical order -->
 		<module>filter-processor</module>
 		<module>groovy-filter-processor</module>

--- a/twitterstream-source/pom.xml
+++ b/twitterstream-source/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>twitterstream-source</artifactId>
+
+	<packaging>jar</packaging>
+	<name>twitterstream-source</name>
+	<description>Spring Cloud Stream twitterstream-source module</description>
+
+	<parent>
+		<groupId>org.springframework.cloud.stream.module</groupId>
+		<artifactId>spring-cloud-stream-modules</artifactId>
+		<version>1.0.0.BUILD-SNAPSHOT</version>
+	</parent>
+
+	<properties>
+		<start-class>org.springframework.cloud.stream.module.twitter.TwitterStreamApplication</start-class>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.social</groupId>
+			<artifactId>spring-social-twitter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud.stream.module</groupId>
+			<artifactId>spring-cloud-stream-modules-common-configuration</artifactId>
+		</dependency>
+	</dependencies>
+</project>

--- a/twitterstream-source/src/main/java/org/springframework/cloud/stream/module/twitter/TwitterStreamApplication.java
+++ b/twitterstream-source/src/main/java/org/springframework/cloud/stream/module/twitter/TwitterStreamApplication.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.module.twitter;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Twitterstream application.
+ *
+ * @author Ilayaperumal Gopinathan
+ */
+@SpringBootApplication
+public class TwitterStreamApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(TwitterStreamApplication.class, args);
+	}
+}

--- a/twitterstream-source/src/main/java/org/springframework/cloud/stream/module/twitter/TwitterStreamMessageProducer.java
+++ b/twitterstream-source/src/main/java/org/springframework/cloud/stream/module/twitter/TwitterStreamMessageProducer.java
@@ -18,9 +18,7 @@ package org.springframework.cloud.stream.module.twitter;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.springframework.cloud.stream.messaging.Source;
 import org.springframework.integration.endpoint.MessageProducerSupport;
-import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.social.twitter.api.StreamDeleteEvent;
 import org.springframework.social.twitter.api.StreamListener;
@@ -88,11 +86,5 @@ class TwitterStreamMessageProducer extends MessageProducerSupport {
 		else {
 			twitterTemplate.streamingOperations().sample(listeners);
 		}
-	}
-
-	@Override
-	public void onInit() {
-		setOutputChannel((MessageChannel) getBeanFactory().getBean(Source.OUTPUT));
-		super.onInit();
 	}
 }

--- a/twitterstream-source/src/main/java/org/springframework/cloud/stream/module/twitter/TwitterStreamMessageProducer.java
+++ b/twitterstream-source/src/main/java/org/springframework/cloud/stream/module/twitter/TwitterStreamMessageProducer.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.stream.module.twitter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.cloud.stream.messaging.Source;
+import org.springframework.integration.endpoint.MessageProducerSupport;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.social.twitter.api.StreamDeleteEvent;
+import org.springframework.social.twitter.api.StreamListener;
+import org.springframework.social.twitter.api.StreamWarningEvent;
+import org.springframework.social.twitter.api.Tweet;
+import org.springframework.social.twitter.api.impl.TwitterTemplate;
+import org.springframework.util.Assert;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ *  {@link org.springframework.integration.core.MessageProducer} implementation to send Twitter stream messages.
+ *
+ * @author Ilayaperumal Gopinathan
+ */
+class TwitterStreamMessageProducer extends MessageProducerSupport {
+
+	private final TwitterTemplate twitterTemplate;
+
+	private final String streamType;
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	TwitterStreamMessageProducer(TwitterTemplate twitterTemplate, String streamType) {
+		Assert.notNull(twitterTemplate, "TwitterTemplate must not be null.");
+		Assert.hasText(streamType, "Stream type must not be empty.");
+		this.twitterTemplate = twitterTemplate;
+		this.streamType = streamType;
+	}
+
+	@Override
+	public void doStart() {
+		List<StreamListener> listeners = new ArrayList<>();
+		listeners.add(new StreamListener() {
+			@Override
+			public void onTweet(Tweet tweet) {
+				try {
+					//todo: Support conversion type; currently the tweet is written as JSON String value.
+					sendMessage(MessageBuilder.withPayload(objectMapper.writeValueAsString(tweet)).build());
+				}
+				catch (JsonProcessingException e) {
+					logger.debug("JSON processing exception while processing the tweet: " + e);
+				}
+			}
+
+			@Override
+			public void onDelete(StreamDeleteEvent deleteEvent) {
+				//discard
+			}
+
+			@Override
+			public void onLimit(int numberOfLimitedTweets) {
+				logger.info("The stream is being track limited for " + numberOfLimitedTweets + " tweets.");
+			}
+
+			@Override
+			public void onWarning(StreamWarningEvent warningEvent) {
+				logger.error("Streaming source is in the danger of being disconnected.");
+			}
+		});
+		if (this.streamType.equalsIgnoreCase(TwitterStreamProperties.FIREHOSE)) {
+			twitterTemplate.streamingOperations().firehose(listeners);
+		}
+		else {
+			twitterTemplate.streamingOperations().sample(listeners);
+		}
+	}
+
+	@Override
+	public void onInit() {
+		setOutputChannel((MessageChannel) getBeanFactory().getBean(Source.OUTPUT));
+		super.onInit();
+	}
+}

--- a/twitterstream-source/src/main/java/org/springframework/cloud/stream/module/twitter/TwitterStreamMessageProducer.java
+++ b/twitterstream-source/src/main/java/org/springframework/cloud/stream/module/twitter/TwitterStreamMessageProducer.java
@@ -39,13 +39,13 @@ class TwitterStreamMessageProducer extends MessageProducerSupport {
 
 	private final TwitterTemplate twitterTemplate;
 
-	private final String streamType;
+	private final TwitterStreamType streamType;
 
 	private final ObjectMapper objectMapper = new ObjectMapper();
 
-	TwitterStreamMessageProducer(TwitterTemplate twitterTemplate, String streamType) {
+	TwitterStreamMessageProducer(TwitterTemplate twitterTemplate, TwitterStreamType streamType) {
 		Assert.notNull(twitterTemplate, "TwitterTemplate must not be null.");
-		Assert.hasText(streamType, "Stream type must not be empty.");
+		Assert.notNull(streamType, "Stream type must not null.");
 		this.twitterTemplate = twitterTemplate;
 		this.streamType = streamType;
 	}
@@ -80,7 +80,7 @@ class TwitterStreamMessageProducer extends MessageProducerSupport {
 				logger.error("Streaming source is in the danger of being disconnected.");
 			}
 		});
-		if (this.streamType.equalsIgnoreCase(TwitterStreamProperties.FIREHOSE)) {
+		if (this.streamType.equals(TwitterStreamType.FIREHOSE)) {
 			twitterTemplate.streamingOperations().firehose(listeners);
 		}
 		else {

--- a/twitterstream-source/src/main/java/org/springframework/cloud/stream/module/twitter/TwitterStreamProperties.java
+++ b/twitterstream-source/src/main/java/org/springframework/cloud/stream/module/twitter/TwitterStreamProperties.java
@@ -26,7 +26,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class TwitterStreamProperties {
 
 	/**
-	 * Twitter stream type
+	 * Twitter stream type (such as sample, firehose). Default is sample.
 	 */
 	private TwitterStreamType streamType = TwitterStreamType.SAMPLE;
 

--- a/twitterstream-source/src/main/java/org/springframework/cloud/stream/module/twitter/TwitterStreamProperties.java
+++ b/twitterstream-source/src/main/java/org/springframework/cloud/stream/module/twitter/TwitterStreamProperties.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.cloud.stream.module.twitter;
 
-import javax.validation.constraints.AssertTrue;
+import javax.validation.constraints.AssertFalse;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -32,11 +32,14 @@ public class TwitterStreamProperties {
 
 	protected static final String FIREHOSE = "firehose";
 
+	/**
+	 * Stream type (sample, firehose)
+	 */
 	private String streamType = SAMPLE;
 
-	@AssertTrue(message = "Only `sample` or `firehose` stream operations are supported.")
-	boolean isStreamTypeValid() {
-		return (this.streamType.equalsIgnoreCase(SAMPLE) || this.streamType.equalsIgnoreCase(FIREHOSE));
+	@AssertFalse(message = "Only `sample` and `firehose` stream operations are supported.")
+	boolean isInvalidStreamType() {
+		return !(this.streamType.equalsIgnoreCase(SAMPLE) || this.streamType.equalsIgnoreCase(FIREHOSE));
 	}
 
 	public String getStreamType() {

--- a/twitterstream-source/src/main/java/org/springframework/cloud/stream/module/twitter/TwitterStreamProperties.java
+++ b/twitterstream-source/src/main/java/org/springframework/cloud/stream/module/twitter/TwitterStreamProperties.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.stream.module.twitter;
+
+import javax.validation.constraints.AssertTrue;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for Twitterstream source.
+ *
+ * @author Ilayaperumal Gopinathan
+ */
+@ConfigurationProperties
+public class TwitterStreamProperties {
+
+	//todo: Support more stream types such as `filter`, `search` that TwitterTemplate implementation supports.
+	protected static final String SAMPLE = "sample";
+
+	protected static final String FIREHOSE = "firehose";
+
+	private String streamType = SAMPLE;
+
+	@AssertTrue(message = "Only `sample` or `firehose` stream operations are supported.")
+	boolean isStreamTypeValid() {
+		return (this.streamType.equalsIgnoreCase(SAMPLE) || this.streamType.equalsIgnoreCase(FIREHOSE));
+	}
+
+	public String getStreamType() {
+		return this.streamType;
+	}
+
+	public void setStreamType(String streamType) {
+		this.streamType = streamType;
+	}
+}

--- a/twitterstream-source/src/main/java/org/springframework/cloud/stream/module/twitter/TwitterStreamSource.java
+++ b/twitterstream-source/src/main/java/org/springframework/cloud/stream/module/twitter/TwitterStreamSource.java
@@ -17,6 +17,7 @@ package org.springframework.cloud.stream.module.twitter;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.stream.annotation.Bindings;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.messaging.Source;
 import org.springframework.context.annotation.Bean;
@@ -38,9 +39,16 @@ public class TwitterStreamSource {
 	@Autowired
 	TwitterStreamProperties streamProperties;
 
+	@Autowired
+	@Bindings(TwitterStreamSource.class)
+	Source source;
+
 	@Bean
 	public MessageProducer twitterStream(TwitterTemplate twitterTemplate) {
-		return new TwitterStreamMessageProducer(twitterTemplate, streamProperties.getStreamType());
+		TwitterStreamMessageProducer messageProducer =
+				new TwitterStreamMessageProducer(twitterTemplate, streamProperties.getStreamType());
+		messageProducer.setOutputChannel(source.output());
+		return messageProducer;
 	}
 
 	@Bean

--- a/twitterstream-source/src/main/java/org/springframework/cloud/stream/module/twitter/TwitterStreamSource.java
+++ b/twitterstream-source/src/main/java/org/springframework/cloud/stream/module/twitter/TwitterStreamSource.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.stream.module.twitter;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.stream.annotation.EnableBinding;
+import org.springframework.cloud.stream.messaging.Source;
+import org.springframework.context.annotation.Bean;
+import org.springframework.integration.core.MessageProducer;
+import org.springframework.social.twitter.api.impl.TwitterTemplate;
+
+/**
+ * TwitterStream source module.
+ *
+ * @author Ilayaperumal Gopinathan
+ */
+@EnableBinding(Source.class)
+@EnableConfigurationProperties({TwitterCredentials.class, TwitterStreamProperties.class})
+public class TwitterStreamSource {
+
+	@Autowired
+	TwitterCredentials credentials;
+
+	@Autowired
+	TwitterStreamProperties streamProperties;
+
+	@Bean
+	public MessageProducer twitterStream(TwitterTemplate twitterTemplate) {
+		return new TwitterStreamMessageProducer(twitterTemplate, streamProperties.getStreamType());
+	}
+
+	@Bean
+	public TwitterTemplate twitterTemplate() {
+		return new TwitterTemplate(credentials.getConsumerKey(), credentials.getConsumerSecret(),
+				credentials.getAccessToken(), credentials.getAccessTokenSecret());
+	}
+}

--- a/twitterstream-source/src/main/java/org/springframework/cloud/stream/module/twitter/TwitterStreamType.java
+++ b/twitterstream-source/src/main/java/org/springframework/cloud/stream/module/twitter/TwitterStreamType.java
@@ -15,26 +15,12 @@
  */
 package org.springframework.cloud.stream.module.twitter;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
-
 /**
- * Configuration properties for Twitterstream source.
+ * Twitter stream types.
  *
  * @author Ilayaperumal Gopinathan
  */
-@ConfigurationProperties
-public class TwitterStreamProperties {
-
-	/**
-	 * Twitter stream type
-	 */
-	private TwitterStreamType streamType = TwitterStreamType.SAMPLE;
-
-	public TwitterStreamType getStreamType() {
-		return this.streamType;
-	}
-
-	public void setStreamType(TwitterStreamType streamType) {
-		this.streamType = streamType;
-	}
+public enum TwitterStreamType {
+	//todo: Support more stream types such as `filter`, `search` that TwitterTemplate implementation supports.
+	SAMPLE, FIREHOSE
 }


### PR DESCRIPTION
- Supports both `sample` and `firehose` streams
- Tightly aligned with `spring-social-twitter`'s TwitterTemplate's operations implementations
