### PR TITLE
Http Client Processor module

### DIFF
--- a/httpclient-processor/README.adoc
+++ b/httpclient-processor/README.adoc
@@ -27,5 +27,4 @@ The following arguments are supported (pass via Spring Cloud Data Flow DSL strin
 * --url : URL of the target resource
 * --httpMethod : HTTP method, e.g., GET, POST, PUT, DELETE
 * --body : HTTP body to send along with the request
-
-(Request headers not yet supported, will be added in a future version).
+* --headers : a map of HTTP headers to send along with the request

--- a/httpclient-processor/README.adoc
+++ b/httpclient-processor/README.adoc
@@ -1,0 +1,31 @@
+= Spring Cloud Stream Http Client Processor
+
+A processor module that makes requests to an HTTP resource and emits the 
+response body as a message payload. This processor can be combined, e.g., 
+with a time source module to periodically poll results from a HTTP resource.
+
+== Requirements
+
+* Java 7 or above
+
+== Build
+
+```
+$> mvn package
+```
+
+== Run
+
+```
+$> java -jar target/httpclient-processor-${version}-exec.jar
+```
+
+== Module Arguments
+
+The following arguments are supported (pass via Spring Cloud Data Flow DSL string):
+
+* --url : URL of the target resource
+* --httpMethod : HTTP method, e.g., GET, POST, PUT, DELETE
+* --body : HTTP body to send along with the request
+
+(Request headers not yet supported, will be added in a future version).

--- a/httpclient-processor/pom.xml
+++ b/httpclient-processor/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>httpclient-processor</artifactId>
+	<packaging>jar</packaging>
+	<name>httpclient-processor</name>
+	<description>Http Client Processor stream module</description>
+
+	<parent>
+		<groupId>org.springframework.cloud.stream.module</groupId>
+		<artifactId>spring-cloud-stream-modules</artifactId>
+		<version>1.0.0.BUILD-SNAPSHOT</version>
+	</parent>
+
+	<properties>
+		<start-class>org.springframework.cloud.stream.module.http.HttpClientProcessorApplication</start-class>
+	</properties>
+
+</project>

--- a/httpclient-processor/src/main/java/org/springframework/cloud/stream/module/http/HttpClientProcessor.java
+++ b/httpclient-processor/src/main/java/org/springframework/cloud/stream/module/http/HttpClientProcessor.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.module.http;
+
+import java.net.URI;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.stream.annotation.EnableBinding;
+import org.springframework.cloud.stream.messaging.Processor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.integration.annotation.Transformer;
+import org.springframework.messaging.Message;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * A processor module that makes requests to an HTTP resource and emits the 
+ * response body as a message payload. This processor can be combined, e.g., 
+ * with a time source module to periodically poll results from a HTTP resource.
+ *
+ * @author Waldemar Hummer
+ */
+@Controller
+@EnableBinding(Processor.class)
+public class HttpClientProcessor {
+
+	private static final Logger LOG = LoggerFactory.getLogger(HttpClientProcessor.class);
+
+	@Autowired
+	private HttpClientProcessorProperties properties;
+
+	@Autowired
+	private RestTemplate restTemplate;
+
+	@Transformer(inputChannel = Processor.INPUT, outputChannel = Processor.OUTPUT)
+	public Object transform(Message<?> message) {
+		try {
+			HttpHeaders headers = new HttpHeaders();
+			// TODO: add headers
+			HttpMethod method = HttpMethod.valueOf(properties.getHttpMethod());
+			URI uri = new URI(properties.getUrl());
+			HttpEntity<?> requestEntity = new RequestEntity<Object>(properties.getBody(), headers, method, uri);
+			ResponseEntity<String> httpResponse = restTemplate.exchange(
+					properties.getUrl(), 
+					HttpMethod.valueOf(properties.getHttpMethod()),
+					requestEntity,
+					String.class);
+			return httpResponse.getBody();
+		} catch (Exception e) {
+			LOG.warn("Error in HTTP request", e);
+			return null;
+		}
+	}
+
+}

--- a/httpclient-processor/src/main/java/org/springframework/cloud/stream/module/http/HttpClientProcessor.java
+++ b/httpclient-processor/src/main/java/org/springframework/cloud/stream/module/http/HttpClientProcessor.java
@@ -17,12 +17,17 @@
 package org.springframework.cloud.stream.module.http;
 
 import java.net.URI;
+import java.util.Map;
+import java.util.Map.Entry;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.stream.annotation.EnableBinding;
+import org.springframework.cloud.stream.config.SpelExpressionConverterConfiguration;
 import org.springframework.cloud.stream.messaging.Processor;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -42,6 +47,8 @@ import org.springframework.web.client.RestTemplate;
  */
 @Controller
 @EnableBinding(Processor.class)
+@Import(SpelExpressionConverterConfiguration.class)
+@EnableConfigurationProperties(HttpClientProcessorProperties.class)
 public class HttpClientProcessor {
 
 	private static final Logger LOG = LoggerFactory.getLogger(HttpClientProcessor.class);
@@ -53,18 +60,34 @@ public class HttpClientProcessor {
 	private RestTemplate restTemplate;
 
 	@Transformer(inputChannel = Processor.INPUT, outputChannel = Processor.OUTPUT)
+	@SuppressWarnings("unchecked")
 	public Object transform(Message<?> message) {
 		try {
+			/* construct headers */
 			HttpHeaders headers = new HttpHeaders();
-			// TODO: add headers
+			if(properties.getHeaders() != null) {
+				Map<String,String> headersMap = properties.getHeaders().getValue(Map.class);
+				for(Entry<String,String> header : headersMap.entrySet()) {
+					headers.add(header.getKey(), header.getValue());
+				}
+			}
+
+			/* determine return type */
+			Class<?> clazz = String.class;
+			if(properties.getExpectedReturnType() != null) {
+				clazz = properties.getExpectedReturnType().getValue(Class.class);
+			}
+
 			HttpMethod method = HttpMethod.valueOf(properties.getHttpMethod());
-			URI uri = new URI(properties.getUrl());
-			HttpEntity<?> requestEntity = new RequestEntity<Object>(properties.getBody(), headers, method, uri);
-			ResponseEntity<String> httpResponse = restTemplate.exchange(
-					properties.getUrl(), 
+			String url = properties.getUrl().getValue(String.class);
+			Object body = properties.getBody() == null ? null : properties.getBody().getValue(message);
+			URI uri = new URI(url);
+			HttpEntity<?> requestEntity = new RequestEntity<Object>(body, headers, method, uri);
+			ResponseEntity<?> httpResponse = restTemplate.exchange(
+					uri, 
 					HttpMethod.valueOf(properties.getHttpMethod()),
 					requestEntity,
-					String.class);
+					clazz);
 			return httpResponse.getBody();
 		} catch (Exception e) {
 			LOG.warn("Error in HTTP request", e);

--- a/httpclient-processor/src/main/java/org/springframework/cloud/stream/module/http/HttpClientProcessorApplication.java
+++ b/httpclient-processor/src/main/java/org/springframework/cloud/stream/module/http/HttpClientProcessorApplication.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.module.http;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * A main application that can be used to run the HTTP Client Processor as a standalone app.
+ *
+ * @author Waldemar Hummer
+ */
+@SpringBootApplication
+public class HttpClientProcessorApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(HttpClientProcessorApplication.class, args);
+	}
+
+}

--- a/httpclient-processor/src/main/java/org/springframework/cloud/stream/module/http/HttpClientProcessorConfiguration.java
+++ b/httpclient-processor/src/main/java/org/springframework/cloud/stream/module/http/HttpClientProcessorConfiguration.java
@@ -1,0 +1,25 @@
+package org.springframework.cloud.stream.module.http;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * @author Waldemar Hummer
+ */
+@Configuration
+@EnableConfigurationProperties(HttpClientProcessorProperties.class)
+public class HttpClientProcessorConfiguration {
+
+	@Autowired
+	private HttpClientProcessorProperties properties;
+
+	@Bean
+	public RestTemplate httpClient() throws Exception {
+		RestTemplate t = new RestTemplate();
+		return t;
+	}
+
+}

--- a/httpclient-processor/src/main/java/org/springframework/cloud/stream/module/http/HttpClientProcessorProperties.java
+++ b/httpclient-processor/src/main/java/org/springframework/cloud/stream/module/http/HttpClientProcessorProperties.java
@@ -1,0 +1,41 @@
+package org.springframework.cloud.stream.module.http;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for the Http Client Processor module.
+ *
+ * @author Waldemar Hummer
+ */
+@ConfigurationProperties
+public class HttpClientProcessorProperties {
+
+	private static final String DEFAULT_HTTP_METHOD = "GET";
+
+	private String url;
+
+	private String httpMethod = DEFAULT_HTTP_METHOD;
+
+	private Object body;
+
+	public String getUrl() {
+		return url;
+	}
+	public void setUrl(String url) {
+		this.url = url;
+	}
+
+	public String getHttpMethod() {
+		return httpMethod;
+	}
+	public void setHttpMethod(String httpMethod) {
+		this.httpMethod = httpMethod;
+	}
+
+	public Object getBody() {
+		return body;
+	}
+	public void setBody(Object body) {
+		this.body = body;
+	}
+
+}

--- a/httpclient-processor/src/main/java/org/springframework/cloud/stream/module/http/HttpClientProcessorProperties.java
+++ b/httpclient-processor/src/main/java/org/springframework/cloud/stream/module/http/HttpClientProcessorProperties.java
@@ -1,5 +1,7 @@
 package org.springframework.cloud.stream.module.http;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.expression.Expression;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
 
 /**
  * Configuration properties for the Http Client Processor module.
@@ -11,16 +13,22 @@ public class HttpClientProcessorProperties {
 
 	private static final String DEFAULT_HTTP_METHOD = "GET";
 
-	private String url;
+	private static final Expression DEFAULT_RETURN_TYPE = new SpelExpressionParser().parseExpression("''.class");
+
+	private Expression url;
 
 	private String httpMethod = DEFAULT_HTTP_METHOD;
 
-	private Object body;
+	private Expression body;
 
-	public String getUrl() {
+	private Expression headers;
+
+	private Expression expectedReturnType = DEFAULT_RETURN_TYPE;
+
+	public Expression getUrl() {
 		return url;
 	}
-	public void setUrl(String url) {
+	public void setUrl(Expression url) {
 		this.url = url;
 	}
 
@@ -31,11 +39,25 @@ public class HttpClientProcessorProperties {
 		this.httpMethod = httpMethod;
 	}
 
-	public Object getBody() {
+	public Expression getBody() {
 		return body;
 	}
-	public void setBody(Object body) {
+	public void setBody(Expression body) {
 		this.body = body;
+	}
+
+	public Expression getHeaders() {
+		return headers;
+	}
+	public void setHeaders(Expression headers) {
+		this.headers = headers;
+	}
+
+	public Expression getExpectedReturnType() {
+		return expectedReturnType;
+	}
+	public void setExpectedReturnType(Expression expectedReturnType) {
+		this.expectedReturnType = expectedReturnType;
 	}
 
 }

--- a/httpclient-processor/src/test/java/org/springframework/cloud/stream/module/http/HttpClientProcessorTests.java
+++ b/httpclient-processor/src/test/java/org/springframework/cloud/stream/module/http/HttpClientProcessorTests.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.module.http;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertThat;
+import static org.springframework.cloud.stream.test.matcher.MessageQueueMatcher.receivesPayloadThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.WebIntegrationTest;
+import org.springframework.cloud.stream.annotation.Bindings;
+import org.springframework.cloud.stream.messaging.Processor;
+import org.springframework.cloud.stream.test.binder.MessageCollector;
+import org.springframework.messaging.support.GenericMessage;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Tests for Http Client Processor.
+ *
+ * @author Waldemar Hummer
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = HttpClientProcessorApplication.class)
+@WebIntegrationTest(randomPort = true)
+@DirtiesContext
+public abstract class HttpClientProcessorTests {
+
+	@Autowired
+	@Bindings(HttpClientProcessor.class)
+	protected Processor channels;
+
+	@Autowired
+	protected MessageCollector messageCollector;
+
+	protected RestTemplate restTemplate = new RestTemplate();
+
+	@WebIntegrationTest(value = "url=http://google.com", randomPort = true)
+	public static class SimpleMappingTests extends HttpClientProcessorTests {
+
+		@Test
+		public void testText() {
+			channels.input().send(new GenericMessage<Object>("hello"));
+			assertThat(messageCollector.forChannel(channels.output()), receivesPayloadThat(containsString("google")));
+		}
+
+	}
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
 		<module>filter-processor</module>
 		<module>groovy-filter-processor</module>
 		<module>groovy-transform-processor</module>
+		<module>httpclient-processor</module>
 		<module>transform-processor</module>
 		<!-- sinks in alphabetical order -->
 		<module>counter-sink</module>


### PR DESCRIPTION
This is a simple implementation of a http client processor module, which aims to reproduce the semantics of `http-client` (in Spring XD) for SCDF.

Example (assuming the module is registered as "http-client"):

```
stream create --name foo --definition "time --fixedDelay=10 | http-client --url='https://httpbin.org/post' --httpMethod=POST --body='{\"foo\":\"bar\"}' | log" --deploy
```

The log output should contain the POSTed data:

```
{
  "url": "https://httpbin.org/post",
  "data": "\\{\\\"foo\\\":\\\"bar\\\"\\}", 
  ...
}
```
