### PR TITLE
Remove optional=true from some module dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,6 @@
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-lattice-core</artifactId>
 			<version>${spring-cloud-lattice.version}</version>
-			<optional>true</optional>
 		</dependency>
 		<!-- Cloud connector dependencies -->
 		<!-- Lattice connector dependency to create services info from lattice -->
@@ -163,19 +162,16 @@
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-lattice-connector</artifactId>
 			<version>${spring-cloud-lattice.version}</version>
-			<optional>true</optional>
 		</dependency>
 		<!-- CF connector dependency to create services info from CF -->
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-cloudfoundry-connector</artifactId>
-			<optional>true</optional>
 		</dependency>
 		<!-- dependency to connect to detected cloud services -->
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-spring-service-connector</artifactId>
-			<optional>true</optional>
 		</dependency>
 		<!--TODO: Move transport related dependencies here pending https://jira.spring.io/browse/XD-3337  -->
 		<dependency>


### PR DESCRIPTION
While IMHO those dependencies should ultimately be added as includes
by the deployers that need them (XD-3615), for the time being they
should really not be marked optional.
They ARE needed at runtime my modules/deployers, but are currently 
excluded because of https://github.com/spring-cloud/spring-cloud-stream/issues/168.
Even when that is fixed (alignment with boot), they still shouldn't be marked
optional.
