### PR TITLE
GH-56: Fix `ScriptVariableProperties` JavaDoc

### DIFF
--- a/common/script-variable-generator/src/main/java/org/springframework/cloud/stream/module/common/ScriptVariableProperties.java
+++ b/common/script-variable-generator/src/main/java/org/springframework/cloud/stream/module/common/ScriptVariableProperties.java
@@ -31,7 +31,7 @@ import org.springframework.core.io.Resource;
 public class ScriptVariableProperties {
 
 	/**
-	 * Variable bindings as a comma delimited string of name-value pairs, e.g. 'foo=bar,baz=car'.
+	 * Variable bindings as a new line delimited string of name-value pairs, e.g. 'foo=bar\n baz=car'.
 	 */
 	private Properties variables;
 

--- a/groovy-transform-processor/src/test/resources/script.groovy
+++ b/groovy-transform-processor/src/test/resources/script.groovy
@@ -1,17 +1,1 @@
-/*
- * Copyright 2015 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-return payload.substring(0, limit as int)
+payload.substring(0, limit as int) + foo


### PR DESCRIPTION
Fixes GH-56 (https://github.com/spring-cloud/spring-cloud-stream-modules/issues/56)

During the test the issue https://github.com/spring-projects/spring-boot/issues/4384 has been discovered.
Hence `TODO` in the `GroovyTransformProcessorIntegrationTests`
