### PR TITLE
Diagnostics for the CassandraSinkIntegrationTests

### DIFF
--- a/cassandra-sink/src/test/java/org/springframework/cloud/stream/module/cassandra/sink/CassandraSinkIntegrationTests.java
+++ b/cassandra-sink/src/test/java/org/springframework/cloud/stream/module/cassandra/sink/CassandraSinkIntegrationTests.java
@@ -63,7 +63,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 @SpringApplicationConfiguration(CassandraSinkApplication.class)
 @IntegrationTest({"spring.cassandra.keyspace=" + CassandraSinkIntegrationTests.CASSANDRA_KEYSPACE,
 		"spring.cassandra.createKeyspace=true"})
-@EmbeddedCassandra(configuration = EmbeddedCassandraServerHelper.CASSANDRA_RNDPORT_YML_FILE)
+@EmbeddedCassandra(configuration = EmbeddedCassandraServerHelper.CASSANDRA_RNDPORT_YML_FILE, timeout = 20000)
 @DirtiesContext
 public abstract class CassandraSinkIntegrationTests {
 

--- a/cassandra-sink/src/test/resources/logback.xml
+++ b/cassandra-sink/src/test/resources/logback.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<configuration>
-    <include resource="org/springframework/boot/logging/logback/base.xml"/>
-	<root level="WARN">
-		<appender-ref ref="CONSOLE" />
-	</root>
-</configuration>


### PR DESCRIPTION
The EmbeddedCassandra used to fail to start during 10 sec period on the CI.
Increase timeout to 20 sec and remove `logback.xml` to have more logging info for diagnostics in the future.

There might be some race condition in the `EmbeddedCassandra` impl.
