### PR TITLE
Port gpfdist sink

### DIFF
--- a/gpfdist-sink/README.md
+++ b/gpfdist-sink/README.md
@@ -1,0 +1,23 @@
+Spring Cloud Stream Gpfdist Sink
+================================
+
+This module writes each message it receives to Gpfdist.
+
+## Requirements:
+
+* Java 7 or Above
+* Redis running on localhost
+* Greenplum DB or HAWQ
+
+## Build:
+
+```
+$ mvn clean package -s ../.settings.xml
+```
+
+## Run:
+
+```
+$ java -jar target/hdfs-sink-1.0.0.BUILD-SNAPSHOT-exec.jar --server.port=8081 --spring.cloud.stream.bindings.input=<name-to-bind-to>
+```
+

--- a/gpfdist-sink/pom.xml
+++ b/gpfdist-sink/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>gpfdist-sink</artifactId>
+	<packaging>jar</packaging>
+	<name>Gpfdist Sink</name>
+	<description>Gpfdist Sink stream module</description>
+
+	<parent>
+		<groupId>org.springframework.cloud.stream.module</groupId>
+		<artifactId>spring-cloud-stream-modules</artifactId>
+		<version>1.0.0.BUILD-SNAPSHOT</version>
+	</parent>
+
+	<properties>
+		<start-class>org.springframework.cloud.stream.module.gpfdist.sink.GpfdistSinkApplication</start-class>
+		<reactor.version>2.0.5.RELEASE</reactor.version>
+		<codahale.version>3.0.2</codahale.version>
+		<netty.version>4.0.27.Final</netty.version>
+		<postgresql.version>9.4-1201-jdbc41</postgresql.version>
+		<skipITs>true</skipITs>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>io.projectreactor</groupId>
+			<artifactId>reactor-core</artifactId>
+			<version>${reactor.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>io.projectreactor</groupId>
+			<artifactId>reactor-net</artifactId>
+			<version>${reactor.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.codahale.metrics</groupId>
+			<artifactId>metrics-core</artifactId>
+			<version>${codahale.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>commons-dbcp</groupId>
+			<artifactId>commons-dbcp</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-jdbc</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.netty</groupId>
+			<artifactId>netty-all</artifactId>
+			<version>${netty.version}</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+			<version>${postgresql.version}</version>
+			<scope>runtime</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<configuration>
+					<skipTests>${skipITs}</skipTests>
+				</configuration>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>integration-test</goal>
+							<goal>verify</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/AbstractGpfdistMessageHandler.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/AbstractGpfdistMessageHandler.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.module.gpfdist.sink;
+
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.context.SmartLifecycle;
+import org.springframework.integration.handler.AbstractMessageHandler;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHandlingException;
+
+/**
+ * Base implementation of Spring Integration {@code MessageHandler} handling {@code Message}.
+ *
+ * @author Janne Valkealahti
+ */
+public abstract class AbstractGpfdistMessageHandler extends AbstractMessageHandler implements SmartLifecycle {
+
+	private static final Log logger = LogFactory.getLog(AbstractGpfdistMessageHandler.class);
+
+	private volatile boolean autoStartup = true;
+
+	private volatile int phase = 0;
+
+	private volatile boolean running;
+
+	private final ReentrantLock lifecycleLock = new ReentrantLock();
+
+	@Override
+	public final boolean isAutoStartup() {
+		return this.autoStartup;
+	}
+
+	@Override
+	public final int getPhase() {
+		return this.phase;
+	}
+
+	@Override
+	public final boolean isRunning() {
+		this.lifecycleLock.lock();
+		try {
+			return this.running;
+		}
+		finally {
+			this.lifecycleLock.unlock();
+		}
+	}
+
+	@Override
+	public final void start() {
+		this.lifecycleLock.lock();
+		try {
+			if (!this.running) {
+				this.doStart();
+				this.running = true;
+				if (logger.isInfoEnabled()) {
+					logger.info("started " + this);
+				}
+				else {
+					if (logger.isDebugEnabled()) {
+						logger.debug("already started " + this);
+					}
+				}
+			}
+		}
+		finally {
+			this.lifecycleLock.unlock();
+		}
+	}
+
+	@Override
+	public final void stop() {
+		this.lifecycleLock.lock();
+		try {
+			if (this.running) {
+				this.doStop();
+				this.running = false;
+				if (logger.isInfoEnabled()) {
+					logger.info("stopped " + this);
+				}
+			}
+			else {
+				if (logger.isDebugEnabled()) {
+					logger.debug("already stopped " + this);
+				}
+			}
+		}
+		finally {
+			this.lifecycleLock.unlock();
+		}
+	}
+
+	@Override
+	public final void stop(Runnable callback) {
+		this.lifecycleLock.lock();
+		try {
+			this.stop();
+			callback.run();
+		}
+		finally {
+			this.lifecycleLock.unlock();
+		}
+	}
+
+	@Override
+	protected final void handleMessageInternal(Message<?> message) throws Exception {
+		try {
+			doWrite(message);
+		}
+		catch (Exception e) {
+			throw new MessageHandlingException(message,
+					"failed to write Message payload to GPDB/HAWQ", e);
+		}
+	}
+
+	/**
+	 * Sets the auto startup.
+	 *
+	 * @param autoStartup the new auto startup
+	 * @see SmartLifecycle
+	 */
+	public void setAutoStartup(boolean autoStartup) {
+		this.autoStartup = autoStartup;
+	}
+
+	/**
+	 * Sets the phase.
+	 *
+	 * @param phase the new phase
+	 * @see SmartLifecycle
+	 */
+	public void setPhase(int phase) {
+		this.phase = phase;
+	}
+
+	/**
+	 * Subclasses may override this method with the start behaviour. This method will be invoked while holding the
+	 * {@link #lifecycleLock}.
+	 */
+	protected void doStart() {
+	};
+
+	/**
+	 * Subclasses may override this method with the stop behaviour. This method will be invoked while holding the
+	 * {@link #lifecycleLock}.
+	 */
+	protected void doStop() {
+	};
+
+	/**
+	 * Subclasses need to implement this method to handle {@link Message} in its writer.
+	 *
+	 * @param message the message to write
+	 */
+	protected abstract void doWrite(Message<?> message) throws Exception;
+
+}

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/GpfdistCodec.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/GpfdistCodec.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.module.gpfdist.sink;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+
+import reactor.fn.Consumer;
+import reactor.fn.Function;
+import reactor.io.buffer.Buffer;
+import reactor.io.codec.Codec;
+
+/**
+ * Gpfdist related reactor {@link Codec}.
+ *
+ * @author Janne Valkealahti
+ */
+public class GpfdistCodec extends Codec<Buffer, Buffer, Buffer> {
+
+	final byte[] h1 = Character.toString('D').getBytes(Charset.forName("UTF-8"));
+
+	@SuppressWarnings("resource")
+	@Override
+	public Buffer apply(Buffer t) {
+			byte[] h2 = ByteBuffer.allocate(4).putInt(t.flip().remaining()).array();
+			return new Buffer().append(h1).append(h2).append(t).flip();
+	}
+
+	@Override
+	public Function<Buffer, Buffer> decoder(Consumer<Buffer> next) {
+		return null;
+	}
+
+}

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/GpfdistConfiguration.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/GpfdistConfiguration.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.module.gpfdist.sink;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import javax.sql.DataSource;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.stream.annotation.EnableBinding;
+import org.springframework.cloud.stream.messaging.Sink;
+import org.springframework.cloud.stream.module.gpfdist.sink.support.ControlFile;
+import org.springframework.cloud.stream.module.gpfdist.sink.support.ControlFileFactoryBean;
+import org.springframework.cloud.stream.module.gpfdist.sink.support.GreenplumDataSourceFactoryBean;
+import org.springframework.cloud.stream.module.gpfdist.sink.support.GreenplumLoad;
+import org.springframework.cloud.stream.module.gpfdist.sink.support.LoadConfiguration;
+import org.springframework.cloud.stream.module.gpfdist.sink.support.LoadConfigurationFactoryBean;
+import org.springframework.cloud.stream.module.gpfdist.sink.support.LoadFactoryBean;
+import org.springframework.cloud.stream.module.gpfdist.sink.support.Mode;
+import org.springframework.cloud.stream.module.gpfdist.sink.support.NetworkUtils;
+import org.springframework.cloud.stream.module.gpfdist.sink.support.ReadableTable;
+import org.springframework.cloud.stream.module.gpfdist.sink.support.ReadableTableFactoryBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.annotation.ServiceActivator;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.util.StringUtils;
+
+/**
+ * Configuration for all beans needed for gpfdist sink.
+ *
+ * @author Janne Valkealahti
+ */
+@Configuration
+@EnableConfigurationProperties(GpfdistSinkProperties.class)
+@EnableBinding(Sink.class)
+public class GpfdistConfiguration {
+
+	@Autowired
+	private GpfdistSinkProperties properties;
+
+	@Bean
+	public TaskScheduler sqlTaskScheduler() {
+		ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
+		taskScheduler.setWaitForTasksToCompleteOnShutdown(true);
+		taskScheduler.setAwaitTerminationSeconds(properties.getBatchTimeout());
+		return taskScheduler;
+	}
+
+	@Bean
+	public ControlFileFactoryBean greenplumControlFile() {
+		ControlFileFactoryBean factoryBean = new ControlFileFactoryBean();
+		factoryBean.setControlFileResource(properties.getControlFile());
+		return factoryBean;
+	}
+
+	@Bean
+	public GreenplumDataSourceFactoryBean dataSource(ControlFile controlFile) {
+		GreenplumDataSourceFactoryBean factoryBean = new GreenplumDataSourceFactoryBean();
+		factoryBean.setControlFile(controlFile);
+		factoryBean.setDbHost(properties.getDbHost());
+		factoryBean.setDbName(properties.getDbName());
+		factoryBean.setDbUser(properties.getDbUser());
+		factoryBean.setDbPassword(properties.getDbPassword());
+		factoryBean.setDbPort(properties.getDbPort());
+		return factoryBean;
+	}
+
+	@Bean
+	public ReadableTableFactoryBean greenplumReadableTable(ControlFile controlFile) {
+		ReadableTableFactoryBean factoryBean = new ReadableTableFactoryBean();
+		factoryBean.setControlFile(controlFile);
+		factoryBean.setDelimiter(properties.getColumnDelimiter());
+		factoryBean.setLocations(Arrays.asList(NetworkUtils.getGPFDistUri(properties.getPort())));
+		return factoryBean;
+	}
+
+	@Bean
+	public LoadConfigurationFactoryBean greenplumLoadConfiguration(ReadableTable externalTable, ControlFile controlFile) {
+		LoadConfigurationFactoryBean factoryBean = new LoadConfigurationFactoryBean();
+		factoryBean.setExternalTable(externalTable);
+		factoryBean.setControlFile(controlFile);
+		factoryBean.setMode(StringUtils.hasText(properties.getMode()) ? Mode.valueOf(properties.getMode().toUpperCase()) : Mode.INSERT);
+		factoryBean.setUpdateColumns(StringUtils.commaDelimitedListToStringArray(properties.getUpdateColumns()));
+		factoryBean.setMatchColumns(StringUtils.commaDelimitedListToStringArray(properties.getMatchColumns()));
+		factoryBean.setTable(properties.getTable());
+		factoryBean.setSqlBefore(StringUtils.hasText(properties.getSqlBefore()) ? Arrays.asList(properties.getSqlBefore()) : new ArrayList<String>());
+		factoryBean.setSqlAfter(StringUtils.hasText(properties.getSqlAfter()) ? Arrays.asList(properties.getSqlAfter()) : new ArrayList<String>());
+		return factoryBean;
+	}
+
+	@Bean
+	public LoadFactoryBean greenplumLoad(LoadConfiguration loadConfiguration, DataSource dataSource) {
+		LoadFactoryBean factoryBean = new LoadFactoryBean();
+		factoryBean.setLoadConfiguration(loadConfiguration);
+		factoryBean.setDataSource(dataSource);
+		return factoryBean;
+	}
+
+	@Bean
+	@ServiceActivator(inputChannel= Sink.INPUT)
+	public GpfdistMessageHandler gpfdist(GreenplumLoad greenplumLoad, TaskScheduler sqlTaskScheduler) {
+		GpfdistMessageHandler handler = new GpfdistMessageHandler(properties.getPort(), properties.getFlushCount(),
+				properties.getFlushTime(), properties.getBatchTimeout(), properties.getBatchCount(), properties.getBatchPeriod(),
+				properties.getDelimiter());
+		handler.setRateInterval(properties.getRateInterval());
+		handler.setGreenplumLoad(greenplumLoad);
+		handler.setSqlTaskScheduler(sqlTaskScheduler);
+		return handler;
+	}
+
+}

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/GpfdistMessageHandler.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/GpfdistMessageHandler.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.module.gpfdist.sink;
+
+import java.util.Date;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.reactivestreams.Processor;
+import org.springframework.cloud.stream.module.gpfdist.sink.support.GreenplumLoad;
+import org.springframework.cloud.stream.module.gpfdist.sink.support.NetworkUtils;
+import org.springframework.cloud.stream.module.gpfdist.sink.support.RuntimeContext;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHandlingException;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.util.StringUtils;
+import org.springframework.util.concurrent.SettableListenableFuture;
+
+import reactor.Environment;
+import reactor.core.processor.RingBufferProcessor;
+import reactor.io.buffer.Buffer;
+
+import com.codahale.metrics.Meter;
+
+/**
+ * Gpfdist related {@code MessageHandler}.
+ *
+ * @author Janne Valkealahti
+ */
+public class GpfdistMessageHandler extends AbstractGpfdistMessageHandler {
+
+	private final Log log = LogFactory.getLog(GpfdistMessageHandler.class);
+
+	private final int port;
+	private final int flushCount;
+	private final int flushTime;
+	private final int batchTimeout;
+	private final int batchCount;
+	private final int batchPeriod;
+	private final String delimiter;
+	private GreenplumLoad greenplumLoad;
+	private Processor<Buffer, Buffer> processor;
+	private GpfdistServer gpfdistServer;
+	private TaskScheduler sqlTaskScheduler;
+	private final TaskFuture taskFuture = new TaskFuture();
+	private int rateInterval = 0;
+	private Meter meter =  null;
+	private int meterCount = 0;
+
+	/**
+	 * Instantiates a new gpfdist message handler.
+	 *
+	 * @param port the port
+	 * @param flushCount the flush count
+	 * @param flushTime the flush time
+	 * @param batchTimeout the batch timeout
+	 * @param batchCount the batch count
+	 * @param batchPeriod the batch period
+	 * @param delimiter the delimiter
+	 */
+	public GpfdistMessageHandler(int port, int flushCount, int flushTime, int batchTimeout, int batchCount,
+			int batchPeriod, String delimiter) {
+		super();
+		this.port = port;
+		this.flushCount = flushCount;
+		this.flushTime = flushTime;
+		this.batchTimeout = batchTimeout;
+		this.batchCount = batchCount;
+		this.batchPeriod = batchPeriod;
+		this.delimiter = StringUtils.hasLength(delimiter) ? delimiter : null;
+	}
+
+	@Override
+	protected void doWrite(Message<?> message) throws Exception {
+		Object payload = message.getPayload();
+		if (payload instanceof String) {
+			String data = (String)payload;
+			if (delimiter != null) {
+				processor.onNext(Buffer.wrap(data+delimiter));
+			} else {
+				processor.onNext(Buffer.wrap(data));
+			}
+			if (meter != null) {
+				if ((meterCount++ % rateInterval) == 0) {
+					meter.mark(rateInterval);
+					log.info("METER: 1 minute rate = " + meter.getOneMinuteRate() + " mean rate = " + meter.getMeanRate());
+				}
+			}
+		} else {
+			throw new MessageHandlingException(message, "message not a String");
+		}
+	}
+
+	@Override
+	protected void onInit() throws Exception {
+		super.onInit();
+		Environment.initializeIfEmpty().assignErrorJournal();
+		processor = RingBufferProcessor.create(false);
+	}
+
+	@Override
+	protected void doStart() {
+		try {
+			log.info("Creating gpfdist protocol listener on port=" + port);
+			gpfdistServer = new GpfdistServer(processor, port, flushCount, flushTime, batchTimeout, batchCount);
+			gpfdistServer.start();
+			log.info("gpfdist protocol listener running on port=" + gpfdistServer.getLocalPort());
+		} catch (Exception e) {
+			throw new RuntimeException("Error starting protocol listener", e);
+		}
+
+		if (greenplumLoad != null) {
+			log.info("Scheduling gpload task with batchPeriod=" + batchPeriod);
+
+			final RuntimeContext context = new RuntimeContext();
+			context.addLocation(NetworkUtils.getGPFDistUri(gpfdistServer.getLocalPort()));
+
+			sqlTaskScheduler.schedule((new FutureTask<Void>(new Runnable() {
+				@Override
+				public void run() {
+					boolean taskValue = true;
+					try {
+						while(!taskFuture.interrupted) {
+							try {
+								greenplumLoad.load(context);
+							} catch (Exception e) {
+								log.error("Error in load", e);
+							}
+							Thread.sleep(batchPeriod*1000);
+						}
+					} catch (Exception e) {
+						taskValue = false;
+					}
+					taskFuture.set(taskValue);
+				}
+			}, null)), new Date());
+
+		} else {
+			log.info("Skipping gpload tasks because greenplumLoad is not set");
+		}
+	}
+
+	@Override
+	protected void doStop() {
+		if (greenplumLoad != null) {
+			taskFuture.interruptTask();
+			try {
+				long now = System.currentTimeMillis();
+				// wait a bit more than batch period
+				Boolean value = taskFuture.get(batchTimeout + batchPeriod + 2, TimeUnit.SECONDS);
+				log.info("Stopping, got future value " + value + " from task which took "
+						+ (System.currentTimeMillis() - now) + "ms");
+			} catch (Exception e) {
+				log.warn("Got error from task wait value which may indicate trouble", e);
+			}
+		}
+
+		try {
+			processor.onComplete();
+			gpfdistServer.stop();
+		} catch (Exception e) {
+			log.warn("Error shutting down protocol listener", e);
+		}
+	}
+
+	/**
+	 * Sets the sql task scheduler.
+	 *
+	 * @param sqlTaskScheduler the new sql task scheduler
+	 */
+	public void setSqlTaskScheduler(TaskScheduler sqlTaskScheduler) {
+		this.sqlTaskScheduler = sqlTaskScheduler;
+	}
+
+	/**
+	 * Sets the greenplum load.
+	 *
+	 * @param greenplumLoad the new greenplum load
+	 */
+	public void setGreenplumLoad(GreenplumLoad greenplumLoad) {
+		this.greenplumLoad = greenplumLoad;
+	}
+
+	/**
+	 * Sets the rate interval.
+	 *
+	 * @param rateInterval the new rate interval
+	 */
+	public void setRateInterval(int rateInterval) {
+		this.rateInterval = rateInterval;
+		if (rateInterval > 0) {
+			meter = new Meter();
+		}
+	}
+
+	private static class TaskFuture extends SettableListenableFuture<Boolean> {
+
+		boolean interrupted = false;
+
+		@Override
+		protected void interruptTask() {
+			interrupted = true;
+		}
+	}
+}

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/GpfdistServer.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/GpfdistServer.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.module.gpfdist.sink;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.reactivestreams.Processor;
+import org.reactivestreams.Publisher;
+
+import reactor.core.processor.RingBufferWorkProcessor;
+import reactor.fn.BiFunction;
+import reactor.fn.Function;
+import reactor.io.buffer.Buffer;
+import reactor.io.net.NetStreams;
+import reactor.io.net.ReactorChannelHandler;
+import reactor.io.net.Spec.HttpServerSpec;
+import reactor.io.net.http.HttpChannel;
+import reactor.io.net.http.HttpServer;
+import reactor.rx.Stream;
+import reactor.rx.Streams;
+
+/**
+ * Server implementation around reactor and netty providing endpoint
+ * where data can be sent using a gpfdist protocol.
+ *
+ * @author Janne Valkealahti
+ */
+public class GpfdistServer {
+
+	private final static Log log = LogFactory.getLog(GpfdistServer.class);
+
+	private final Processor<Buffer, Buffer> processor;
+	private final int port;
+	private final int flushCount;
+	private final int flushTime;
+	private final int batchTimeout;
+	private final int batchCount;
+	private HttpServer<Buffer, Buffer> server;
+	private int localPort = -1;
+
+	/**
+	 * Instantiates a new gpfdist server.
+	 *
+	 * @param processor the processor
+	 * @param port the port
+	 * @param flushCount the flush count
+	 * @param flushTime the flush time
+	 * @param batchTimeout the batch timeout
+	 * @param batchCount the batch count
+	 */
+	public GpfdistServer(Processor<Buffer, Buffer> processor, int port, int flushCount, int flushTime,
+			int batchTimeout, int batchCount) {
+		this.processor = processor;
+		this.port = port;
+		this.flushCount = flushCount;
+		this.flushTime = flushTime;
+		this.batchTimeout = batchTimeout;
+		this.batchCount = batchCount;
+	}
+
+	/**
+	 * Start a server.
+	 *
+	 * @return the http server
+	 * @throws Exception the exception
+	 */
+	public synchronized HttpServer<Buffer, Buffer> start() throws Exception {
+		if (server == null) {
+			server = createProtocolListener();
+		}
+		return server;
+	}
+
+	/**
+	 * Stop a server.
+	 *
+	 * @throws Exception the exception
+	 */
+	public synchronized void stop() throws Exception {
+		if (server != null) {
+			server.shutdown().awaitSuccess();
+		}
+		server = null;
+	}
+
+	/**
+	 * Gets the local port.
+	 *
+	 * @return the local port
+	 */
+	public int getLocalPort() {
+		return localPort;
+	}
+
+	private HttpServer<Buffer, Buffer> createProtocolListener()
+			throws Exception {
+
+		final Stream<Buffer> stream = Streams
+		.wrap(processor)
+		.window(flushCount, flushTime, TimeUnit.SECONDS)
+		.flatMap(new Function<Stream<Buffer>, Publisher<Buffer>>() {
+
+			@Override
+			public Publisher<Buffer> apply(Stream<Buffer> t) {
+
+				return t.reduce(new Buffer(), new BiFunction<Buffer, Buffer, Buffer>() {
+
+					@Override
+					public Buffer apply(Buffer prev, Buffer next) {
+						return prev.append(next);
+					}
+				});
+			}
+		})
+		.process(RingBufferWorkProcessor.<Buffer>create("gpfdist-sink-worker", 8192, false));
+
+		HttpServer<Buffer, Buffer> httpServer = NetStreams
+				.httpServer(new Function<HttpServerSpec<Buffer, Buffer>, HttpServerSpec<Buffer, Buffer>>() {
+
+					@Override
+					public HttpServerSpec<Buffer, Buffer> apply(HttpServerSpec<Buffer, Buffer> server) {
+						return server
+								.codec(new GpfdistCodec())
+								.listen(port);
+					}
+				});
+
+		httpServer.get("/data", new ReactorChannelHandler<Buffer, Buffer, HttpChannel<Buffer,Buffer>>() {
+
+			@Override
+			public Publisher<Void> apply(HttpChannel<Buffer, Buffer> request) {
+				request.responseHeaders().removeTransferEncodingChunked();
+				request.addResponseHeader("Content-type", "text/plain");
+				request.addResponseHeader("Expires", "0");
+				request.addResponseHeader("X-GPFDIST-VERSION", "Spring XD");
+				request.addResponseHeader("X-GP-PROTO", "1");
+				request.addResponseHeader("Cache-Control", "no-cache");
+				request.addResponseHeader("Connection", "close");
+
+				return request.writeWith(stream
+						.take(batchCount)
+						.timeout(batchTimeout, TimeUnit.SECONDS, Streams.<Buffer>empty())
+						.concatWith(Streams.just(Buffer.wrap(new byte[0]))))
+						.capacity(1l);
+			}
+		});
+
+		httpServer.start().awaitSuccess();
+		log.info("Server running using address=[" + httpServer.getListenAddress() + "]");
+		localPort = httpServer.getListenAddress().getPort();
+		return httpServer;
+	}
+
+}

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/GpfdistSinkApplication.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/GpfdistSinkApplication.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.module.gpfdist.sink;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+
+/**
+ * Spring Boot app running gpfdist sink application.
+ *
+ * @author Janne Valkealahti
+ */
+@SpringBootApplication(exclude = DataSourceAutoConfiguration.class)
+public class GpfdistSinkApplication {
+	// explicitly exclude DataSourceAutoConfiguration as it is
+	// interfering too much with data source config for gpdb.
+
+	public static void main(String[] args) throws InterruptedException {
+		SpringApplication.run(GpfdistSinkApplication.class, args);
+	}
+
+}

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/GpfdistSinkProperties.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/GpfdistSinkProperties.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.module.gpfdist.sink;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.core.io.Resource;
+
+/**
+ * Config options for gpfdist sink.
+ *
+ * @author Janne Valkealahti
+ */
+@ConfigurationProperties
+public class GpfdistSinkProperties {
+
+	private int port = 0;
+	private int flushCount = 100;
+	private int flushTime = 2;
+	private int batchTimeout = 4;
+	private int batchCount = 100;
+	private int batchPeriod = 10;
+	private String dbName = "gpadmin";
+	private String dbUser = "gpadmin";
+	private String dbPassword = "gpadmin";
+	private String dbHost = "localhost";
+	private int dbPort = 5432;
+	private Resource controlFile;
+	private String delimiter = "\n";
+	private Character columnDelimiter;
+	private String mode;
+	private String matchColumns;
+	private String updateColumns;
+	private String table;
+	private int rateInterval = 0;
+	private String sqlBefore;
+	private String sqlAfter;
+
+	public int getPort() {
+		return port;
+	}
+
+	public void setPort(int port) {
+		this.port = port;
+	}
+
+	public int getFlushCount() {
+		return flushCount;
+	}
+
+	public void setFlushCount(int flushCount) {
+		this.flushCount = flushCount;
+	}
+
+	public int getFlushTime() {
+		return flushTime;
+	}
+
+	public void setFlushTime(int flushTime) {
+		this.flushTime = flushTime;
+	}
+
+	public int getBatchTimeout() {
+		return batchTimeout;
+	}
+
+	public void setBatchTimeout(int batchTimeout) {
+		this.batchTimeout = batchTimeout;
+	}
+
+	public int getBatchPeriod() {
+		return batchPeriod;
+	}
+
+	public void setBatchPeriod(int batchPeriod) {
+		this.batchPeriod = batchPeriod;
+	}
+
+	public int getBatchCount() {
+		return batchCount;
+	}
+
+	public void setBatchCount(int batchCount) {
+		this.batchCount = batchCount;
+	}
+
+	public String getDbName() {
+		return dbName;
+	}
+
+	public void setDbName(String dbName) {
+		this.dbName = dbName;
+	}
+
+	public String getDbUser() {
+		return dbUser;
+	}
+
+	public void setDbUser(String dbUser) {
+		this.dbUser = dbUser;
+	}
+
+	public String getDbPassword() {
+		return dbPassword;
+	}
+
+	public void setDbPassword(String dbPassword) {
+		this.dbPassword = dbPassword;
+	}
+
+	public String getDbHost() {
+		return dbHost;
+	}
+
+	public void setDbHost(String dbHost) {
+		this.dbHost = dbHost;
+	}
+
+	public int getDbPort() {
+		return dbPort;
+	}
+
+	public void setDbPort(int dbPort) {
+		this.dbPort = dbPort;
+	}
+
+	public Resource getControlFile() {
+		return controlFile;
+	}
+
+	public void setControlFile(Resource controlFile) {
+		this.controlFile = controlFile;
+	}
+
+	public String getDelimiter() {
+		return delimiter;
+	}
+
+	public void setDelimiter(String delimiter) {
+		this.delimiter = delimiter;
+	}
+
+	public Character getColumnDelimiter() {
+		return columnDelimiter;
+	}
+
+	public void setColumnDelimiter(Character columnDelimiter) {
+		this.columnDelimiter = columnDelimiter;
+	}
+
+	public String getMode() {
+		return mode;
+	}
+
+	public void setMode(String mode) {
+		this.mode = mode;
+	}
+
+	public String getUpdateColumns() {
+		return updateColumns;
+	}
+
+	public void setUpdateColumns(String updateColumns) {
+		this.updateColumns = updateColumns;
+	}
+
+	public String getMatchColumns() {
+		return matchColumns;
+	}
+
+	public void setMatchColumns(String matchColumns) {
+		this.matchColumns = matchColumns;
+	}
+
+	public String getTable() {
+		return table;
+	}
+
+	public void setTable(String table) {
+		this.table = table;
+	}
+
+	public int getRateInterval() {
+		return rateInterval;
+	}
+
+	public void setRateInterval(int rateInterval) {
+		this.rateInterval = rateInterval;
+	}
+
+	public String getSqlBefore() {
+		return sqlBefore;
+	}
+
+	public void setSqlBefore(String sqlBefore) {
+		this.sqlBefore = sqlBefore;
+	}
+
+	public String getSqlAfter() {
+		return sqlAfter;
+	}
+
+	public void setSqlAfter(String sqlAfter) {
+		this.sqlAfter = sqlAfter;
+	}
+
+}

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/AbstractExternalTable.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/AbstractExternalTable.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.module.gpfdist.sink.support;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Base settings for all external tables;
+ *
+ * @since 1.2
+ * @author Janne Valkealahti
+ * @author Gary Russell
+ *
+ */
+public abstract class AbstractExternalTable {
+
+	// LOCATION
+	private List<String> locations;
+
+	// FORMAT 'TEXT'|'CVS'
+	private Format format;
+
+	// [DELIMITER [AS] 'delimiter' | 'OFF']
+	private Character delimiter;
+
+	// [NULL [AS] 'null string']
+	private String nullString;
+
+	// [ESCAPE [AS] 'escape' | 'OFF']
+	private Character escape;
+
+	// [QUOTE [AS] 'quote']
+	private Character formatQuote;
+
+	// [FORCE NOT NULL column [, ...]]
+	private String[] formatForceQuote;
+
+	// [ ENCODING 'encoding' ]
+	private String encoding;
+
+	private String like;
+
+	private String columns;
+
+	public List<String> getLocations() {
+		return locations;
+	}
+
+	public void setLocations(List<String> locations) {
+		this.locations = new ArrayList<String>(locations);
+	}
+
+	public void setTextFormat() {
+		this.format = Format.TEXT;
+	}
+
+	public void setTextFormat(Character delimiter, String nullString, Character escape) {
+		this.format = Format.TEXT;
+		this.delimiter = delimiter;
+		this.nullString = nullString;
+		this.escape = escape;
+	}
+
+	public void setCsvFormat() {
+		this.format = Format.CSV;
+	}
+
+	public void setCsvFormat(Character quote, Character delimiter, String nullString, String[] forceQuote,
+			Character escape) {
+		this.format = Format.CSV;
+		this.formatQuote = quote;
+		this.delimiter = delimiter;
+		this.nullString = nullString;
+		this.escape = escape;
+		this.formatForceQuote = Arrays.copyOf(forceQuote, forceQuote.length);
+	}
+
+	public Format getFormat() {
+		return format;
+	}
+
+	public Character getDelimiter() {
+		return delimiter;
+	}
+
+	public void setDelimiter(Character delimiter) {
+		this.delimiter = delimiter;
+	}
+
+	public String getNullString() {
+		return nullString;
+	}
+
+	public void setNullString(String nullString) {
+		this.nullString = nullString;
+	}
+
+	public Character getEscape() {
+		return escape;
+	}
+
+	public void setEscape(Character escape) {
+		this.escape = escape;
+	}
+
+	public Character getQuote() {
+		return formatQuote;
+	}
+
+	public void setQuote(Character quote) {
+		this.formatQuote = quote;
+	}
+
+	public String[] getForceQuote() {
+		return formatForceQuote;
+	}
+
+	public void setForceQuote(String[] forceQuote) {
+		this.formatForceQuote = Arrays.copyOf(forceQuote, forceQuote.length);
+	}
+
+	public String getEncoding() {
+		return encoding;
+	}
+
+	public void setEncoding(String encoding) {
+		this.encoding = encoding;
+	}
+
+	public String getLike() {
+		return like;
+	}
+
+	public void setLike(String like) {
+		this.like = like;
+	}
+
+	public String getColumns() {
+		return columns;
+	}
+
+	public void setColumns(String columns) {
+		this.columns = columns;
+	}
+
+}

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/ControlFile.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/ControlFile.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.module.gpfdist.sink.support;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ControlFile {
+
+	private Character gploadInputDelimiter;
+
+	private String gploadOutputTable;
+
+	private List<String> gploadOutputMatchColumns;
+
+	private List<String> gploadOutputUpdateColumns;
+
+	private String gploadOutputUpdateCondition;
+
+	private OutputMode gploadOutputMode;
+
+	private String database;
+
+	private String user;
+
+	private String password;
+
+	private String host;
+
+	private Integer port;
+
+	private final List<String> gploadSqlBefore = new ArrayList<String>();
+
+	private final List<String> gploadSqlAfter = new ArrayList<String>();
+
+	public Character getGploadInputDelimiter() {
+		return gploadInputDelimiter;
+	}
+
+	public void setGploadInputDelimiter(Character gploadInputDelimiter) {
+		this.gploadInputDelimiter = gploadInputDelimiter;
+	}
+
+	public String getGploadOutputTable() {
+		return gploadOutputTable;
+	}
+
+	public void setGploadOutputTable(String gploadOutputTable) {
+		this.gploadOutputTable = gploadOutputTable;
+	}
+
+	public List<String> getGploadOutputMatchColumns() {
+		return gploadOutputMatchColumns;
+	}
+
+	public void setGploadOutputMatchColumns(List<String> gploadOutputMatchColumns) {
+		this.gploadOutputMatchColumns = gploadOutputMatchColumns;
+	}
+
+	public List<String> getGploadOutputUpdateColumns() {
+		return gploadOutputUpdateColumns;
+	}
+
+	public void setGploadOutputUpdateColumns(List<String> gploadOutputUpdateColumns) {
+		this.gploadOutputUpdateColumns = gploadOutputUpdateColumns;
+	}
+
+	public String getGploadOutputUpdateCondition() {
+		return gploadOutputUpdateCondition;
+	}
+
+	public void setGploadOutputUpdateCondition(String gploadOutputUpdateCondition) {
+		this.gploadOutputUpdateCondition = gploadOutputUpdateCondition;
+	}
+
+	public OutputMode getGploadOutputMode() {
+		return gploadOutputMode;
+	}
+
+	public void setGploadOutputMode(OutputMode gploadOutputMode) {
+		this.gploadOutputMode = gploadOutputMode;
+	}
+
+	public String getDatabase() {
+		return database;
+	}
+
+	public void setDatabase(String database) {
+		this.database = database;
+	}
+
+	public String getUser() {
+		return user;
+	}
+
+	public void setUser(String user) {
+		this.user = user;
+	}
+
+	public String getPassword() {
+		return password;
+	}
+
+	public void setPassword(String password) {
+		this.password = password;
+	}
+
+	public String getHost() {
+		return host;
+	}
+
+	public void setHost(String host) {
+		this.host = host;
+	}
+
+	public Integer getPort() {
+		return port;
+	}
+
+	public void setPort(Integer port) {
+		this.port = port;
+	}
+
+	public List<String> getGploadSqlBefore() {
+		return gploadSqlBefore;
+	}
+
+	public void addGploadSqlBefore(String gploadSqlBefore) {
+		this.gploadSqlBefore.add(gploadSqlBefore);
+	}
+
+	public List<String> getGploadSqlAfter() {
+		return gploadSqlAfter;
+	}
+
+	public void addGploadSqlAfter(String gploadSqlAfter) {
+		this.gploadSqlAfter.add(gploadSqlAfter);
+	}
+
+	public enum OutputMode {
+		INSERT, UPDATE, MERGE
+	}
+
+}

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/ControlFileFactoryBean.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/ControlFileFactoryBean.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.module.gpfdist.sink.support;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.config.YamlMapFactoryBean;
+import org.springframework.cloud.stream.module.gpfdist.sink.support.ControlFile.OutputMode;
+import org.springframework.core.io.Resource;
+
+public class ControlFileFactoryBean implements FactoryBean<ControlFile>, InitializingBean {
+
+	private ControlFile controlFile;
+
+	private Resource controlFileResource;
+
+	@Override
+	public void afterPropertiesSet() throws Exception {
+		if (controlFileResource != null) {
+			controlFile = parseYaml();
+		}
+		else {
+			controlFile = new ControlFile();
+		}
+	}
+
+	@Override
+	public ControlFile getObject() throws Exception {
+		return controlFile;
+	}
+
+	@Override
+	public Class<ControlFile> getObjectType() {
+		return ControlFile.class;
+	}
+
+	@Override
+	public boolean isSingleton() {
+		return true;
+	}
+
+	public void setControlFileResource(Resource controlFileResource) {
+		this.controlFileResource = controlFileResource;
+	}
+
+	@SuppressWarnings({ "unchecked" })
+	private ControlFile parseYaml() {
+		ControlFile cf = new ControlFile();
+		YamlMapFactoryBean factory = new YamlMapFactoryBean();
+		factory.setResources(controlFileResource);
+		Map<String, Object> yaml = factory.getObject();
+
+		// main map
+		for (Entry<String, Object> e0 : yaml.entrySet()) {
+			if (e0.getKey().toLowerCase().equals("gpload")) {
+				if (e0.getValue() instanceof Map) {
+					Map<String, Object> gploadMap = (Map<String, Object>) e0.getValue();
+
+					// GPLOAD map
+					for (Entry<String, Object> e1 : gploadMap.entrySet()) {
+						if (e1.getKey().toLowerCase().equals("output")) {
+
+							// GPLOAD.OUTPUT list
+							if (e1.getValue() instanceof List) {
+								for (Object v : (List<?>) e1.getValue()) {
+									if (v instanceof Map) {
+										Map<String, Object> tableMap = (Map<String, Object>) v;
+										for (Entry<String, Object> e2 : tableMap.entrySet()) {
+											if (e2.getKey().toLowerCase().equals("table")) {
+												if (e2.getValue() instanceof String) {
+													cf.setGploadOutputTable((String) e2.getValue());
+												}
+											}
+											else if (e2.getKey().toLowerCase().equals("mode")) {
+												if (e2.getValue() instanceof String) {
+													cf.setGploadOutputMode(OutputMode.valueOf(((String) e2.getValue()).toUpperCase()));
+												}
+											}
+											else if (e2.getKey().toLowerCase().equals("match_columns")) {
+												if (e2.getValue() instanceof List) {
+													cf.setGploadOutputMatchColumns(((List<String>) e2.getValue()));
+												}
+											}
+											else if (e2.getKey().toLowerCase().equals("update_columns")) {
+												if (e2.getValue() instanceof List) {
+													cf.setGploadOutputUpdateColumns(((List<String>) e2.getValue()));
+												}
+											}
+											else if (e2.getKey().toLowerCase().equals("update_condition")) {
+												if (e2.getValue() instanceof String) {
+													cf.setGploadOutputUpdateCondition((String) e2.getValue());
+												}
+											}
+										}
+
+									}
+								}
+							}
+						}
+						else if (e1.getKey().toLowerCase().equals("input")) {
+							if (e1.getValue() instanceof List) {
+								for (Object v : (List<?>) e1.getValue()) {
+									if (v instanceof Map) {
+										Map<String, Object> tableMap = (Map<String, Object>) v;
+										for (Entry<String, Object> e2 : tableMap.entrySet()) {
+											if (e2.getKey().toLowerCase().equals("delimiter")) {
+												if (e2.getValue() instanceof Character) {
+													cf.setGploadInputDelimiter((Character) e2.getValue());
+												}
+												else if (e2.getValue() instanceof String) {
+													if (((String) e2.getValue()).length() == 1) {
+														cf.setGploadInputDelimiter(((String) e2.getValue()).charAt(0));
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+						else if (e1.getKey().toLowerCase().equals("sql")) {
+							if (e1.getValue() instanceof List) {
+								for (Object v : (List<?>) e1.getValue()) {
+									if (v instanceof Map) {
+										Map<String, Object> sqlMap = (Map<String, Object>) v;
+										for (Entry<String, Object> e2 : sqlMap.entrySet()) {
+											if (e2.getKey().toLowerCase().equals("before")) {
+												if (e2.getValue() instanceof String) {
+													cf.addGploadSqlBefore((String) e2.getValue());
+												}
+											}
+											else if (e2.getKey().toLowerCase().equals("after")) {
+												if (e2.getValue() instanceof String) {
+													cf.addGploadSqlAfter((String) e2.getValue());
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+			else if (e0.getKey().toLowerCase().equals("database")) {
+				if (e0.getValue() instanceof String) {
+					cf.setDatabase((String) e0.getValue());
+				}
+			}
+			else if (e0.getKey().toLowerCase().equals("user")) {
+				if (e0.getValue() instanceof String) {
+					cf.setUser((String) e0.getValue());
+				}
+			}
+			else if (e0.getKey().toLowerCase().equals("password")) {
+				if (e0.getValue() instanceof String) {
+					cf.setPassword((String) e0.getValue());
+				}
+			}
+			else if (e0.getKey().toLowerCase().equals("host")) {
+				if (e0.getValue() instanceof String) {
+					cf.setHost((String) e0.getValue());
+				}
+			}
+			else if (e0.getKey().toLowerCase().equals("port")) {
+				if (e0.getValue() instanceof Integer) {
+					cf.setPort((Integer) e0.getValue());
+				}
+			}
+		}
+		return cf;
+	}
+
+}

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/DefaultGreenplumLoad.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/DefaultGreenplumLoad.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.stream.module.gpfdist.sink.support;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.util.Assert;
+
+public class DefaultGreenplumLoad implements GreenplumLoad {
+
+	private final static Log log = LogFactory.getLog(DefaultGreenplumLoad.class);
+
+	private final LoadService loadService;
+
+	private final LoadConfiguration loadConfiguration;
+
+	public DefaultGreenplumLoad(LoadConfiguration loadConfiguration, LoadService loadService) {
+		this.loadConfiguration = loadConfiguration;
+		this.loadService = loadService;
+		Assert.notNull(loadConfiguration, "Load configuration must be set");
+		Assert.notNull(loadService, "Load service must be set");
+	}
+
+	@Override
+	public void load() {
+		load(null);
+	}
+
+	@Override
+	public void load(RuntimeContext context) {
+		log.debug("Doing greenplum load");
+		loadService.load(loadConfiguration, context);
+	}
+
+}

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/DefaultLoadService.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/DefaultLoadService.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.module.gpfdist.sink.support;
+
+import java.util.UUID;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.util.Assert;
+
+public class DefaultLoadService implements LoadService {
+
+	private final JdbcTemplate jdbcTemplate;
+
+	public DefaultLoadService(JdbcTemplate jdbcTemplate) {
+		this.jdbcTemplate = jdbcTemplate;
+		Assert.notNull(jdbcTemplate, "JdbcTemplate must be set");
+	}
+
+	@Override
+	public void load(LoadConfiguration loadConfiguration) {
+		load(loadConfiguration, null);
+	}
+
+	@Override
+	public void load(LoadConfiguration loadConfiguration, RuntimeContext context) {
+		String prefix = UUID.randomUUID().toString().replaceAll("-", "_");
+
+		// setup jdbc operations
+		JdbcCommands operations = new JdbcCommands(jdbcTemplate);
+
+		String sqlCreateTable = SqlUtils.createExternalReadableTable(loadConfiguration, prefix,
+				context != null ? context.getLocations() : null);
+		String sqlDropTable = SqlUtils.dropExternalReadableTable(loadConfiguration, prefix);
+		String sqlInsert = SqlUtils.load(loadConfiguration, prefix);
+
+		operations.setPrepareSql(sqlCreateTable);
+		operations.setCleanSql(sqlDropTable);
+		operations.setRunSql(sqlInsert);
+
+		operations.setBeforeSqls(loadConfiguration.getSqlBefore());
+		operations.setAfterSqls(loadConfiguration.getSqlAfter());
+
+		if (!operations.execute() && operations.getLastException() != null) {
+			throw operations.getLastException();
+		}
+	}
+
+}

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/Format.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/Format.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.stream.module.gpfdist.sink.support;
+
+public enum Format {
+
+	TEXT, CSV
+
+}

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/GreenplumDataSourceFactoryBean.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/GreenplumDataSourceFactoryBean.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.module.gpfdist.sink.support;
+
+import javax.sql.DataSource;
+
+import org.apache.commons.dbcp.BasicDataSource;
+
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+import org.springframework.util.StringUtils;
+
+/**
+ * Factory bean for configuring a {@link DataSource}. Needed to use
+ * both command-line props and a control file.
+ *
+ * @author Janne Valkealahti
+ */
+public class GreenplumDataSourceFactoryBean extends AbstractFactoryBean<BasicDataSource> {
+
+	private ControlFile controlFile;
+
+	private String dbHost = "localhost";
+
+	private String dbName = "gpadmin";
+
+	private String dbUser = "gpadmin";
+
+	private String dbPassword = "gpadmin";
+
+	private int dbPort = 5432;
+
+	@Override
+	public Class<DataSource> getObjectType() {
+		return DataSource.class;
+	}
+
+	@Override
+	protected BasicDataSource createInstance() throws Exception {
+		BasicDataSource ds = new BasicDataSource();
+		ds.setDriverClassName("org.postgresql.Driver");
+		if (StringUtils.hasText(dbUser)) {
+			ds.setUsername(dbUser);
+		}
+		if (StringUtils.hasText(dbPassword)) {
+			ds.setPassword(dbPassword);
+		}
+		ds.setUrl("jdbc:postgresql://" + dbHost + ":" + dbPort + "/" + dbName);
+		return ds;
+	}
+
+	@Override
+	public void afterPropertiesSet() throws Exception {
+		if (controlFile != null) {
+			if (StringUtils.hasText(controlFile.getHost())) {
+				dbHost = controlFile.getHost();
+			}
+			if (StringUtils.hasText(controlFile.getDatabase())) {
+				dbName = controlFile.getDatabase();
+			}
+			if (StringUtils.hasText(controlFile.getUser())) {
+				dbUser = controlFile.getUser();
+			}
+			if (StringUtils.hasText(controlFile.getPassword())) {
+				dbPassword = controlFile.getPassword();
+			}
+			if (controlFile.getPort() != null) {
+				dbPort = controlFile.getPort();
+			}
+		}
+		super.afterPropertiesSet();
+	}
+
+	@Override
+	protected void destroyInstance(BasicDataSource instance) throws Exception {
+		instance.close();
+	}
+
+	public void setControlFile(ControlFile controlFile) {
+		this.controlFile = controlFile;
+	}
+
+	public void setDbHost(String dbHost) {
+		this.dbHost = dbHost;
+	}
+
+
+	public void setDbName(String dbName) {
+		this.dbName = dbName;
+	}
+
+
+	public void setDbUser(String dbUser) {
+		this.dbUser = dbUser;
+	}
+
+
+	public void setDbPassword(String dbPassword) {
+		this.dbPassword = dbPassword;
+	}
+
+
+	public void setDbPort(int dbPort) {
+		this.dbPort = dbPort;
+	}
+
+}

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/GreenplumLoad.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/GreenplumLoad.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.stream.module.gpfdist.sink.support;
+
+import org.springframework.cloud.stream.module.gpfdist.sink.support.RuntimeContext;
+
+public interface GreenplumLoad {
+
+	public void load();
+
+	public void load(RuntimeContext context);
+
+}

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/JdbcCommands.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/JdbcCommands.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.module.gpfdist.sink.support;
+
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.util.StringUtils;
+
+/**
+ * Utility class helping to execute jdbc operations within a load session.
+ * Provides a way to prepare, run and clean a main load command. Additionally
+ * it can use a list of before and after commands which are execute before and after
+ * of a main command. Clean command is executed last even if some of the other
+ * commands fail.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class JdbcCommands {
+
+	private static final Log log = LogFactory.getLog(JdbcCommands.class);
+
+	private JdbcTemplate jdbcTemplate;
+
+	private List<String> beforeSqls;
+
+	private List<String> afterSqls;
+
+	private String prepareSql;
+
+	private String runSql;
+
+	private String cleanSql;
+
+	private DataAccessException lastException;
+
+	public JdbcCommands(JdbcTemplate jdbcTemplate) {
+		this.jdbcTemplate = jdbcTemplate;
+	}
+
+	public void setJdbcTemplate(JdbcTemplate jdbcTemplate) {
+		this.jdbcTemplate = jdbcTemplate;
+	}
+
+	public void setPrepareSql(String sql) {
+		this.prepareSql = sql;
+	}
+
+	public void setRunSql(String sql) {
+		this.runSql = sql;
+	}
+
+	public void setCleanSql(String sql) {
+		this.cleanSql = sql;
+	}
+
+	public void setBeforeSqls(List<String> beforeSqls) {
+		this.beforeSqls = beforeSqls;
+	}
+
+	public void setAfterSqls(List<String> afterSqls) {
+		this.afterSqls = afterSqls;
+	}
+
+	public boolean execute() {
+		boolean succeed = true;
+
+		try {
+			succeed = prepare();
+			if (succeed) {
+				succeed = before();
+			}
+			if (succeed) {
+				succeed = run();
+			}
+			if (succeed) {
+				succeed = after();
+			}
+		}
+		catch (Exception e) {
+		}
+		finally {
+			try {
+				clean();
+			}
+			catch (Exception e2) {
+			}
+		}
+		return succeed;
+	}
+
+	public DataAccessException getLastException() {
+		return lastException;
+	}
+
+	private boolean prepare() {
+		try {
+			if (log.isDebugEnabled()) {
+				log.debug("Executing prepare: " + prepareSql);
+			}
+			jdbcTemplate.execute(prepareSql);
+		}
+		catch (DataAccessException e) {
+			lastException = e;
+			return false;
+		}
+		return true;
+	}
+
+	private boolean run() {
+		try {
+			if (log.isDebugEnabled()) {
+				log.debug("Executing run: " + runSql);
+			}
+			jdbcTemplate.execute(runSql);
+		}
+		catch (DataAccessException e) {
+			lastException = e;
+			return false;
+		}
+		return true;
+	}
+
+	private boolean clean() {
+		try {
+			if (log.isDebugEnabled()) {
+				log.debug("Executing clean: " + cleanSql);
+			}
+			jdbcTemplate.execute(cleanSql);
+		}
+		catch (DataAccessException e) {
+			lastException = e;
+			return false;
+		}
+		return true;
+	}
+
+	private boolean before() {
+		if (beforeSqls != null) {
+			for (String sql : beforeSqls) {
+				if (!StringUtils.hasText(sql)) {
+					continue;
+				}
+				if (log.isDebugEnabled()) {
+					log.debug("Executing before: " + sql);
+				}
+				try {
+					jdbcTemplate.execute(sql);
+				}
+				catch (DataAccessException e) {
+					lastException = e;
+					return false;
+				}
+			}
+		}
+		return true;
+	}
+
+	private boolean after() {
+		if (afterSqls != null) {
+			for (String sql : afterSqls) {
+				if (!StringUtils.hasText(sql)) {
+					continue;
+				}
+				if (log.isDebugEnabled()) {
+					log.debug("Executing after: " + sql);
+				}
+				try {
+					jdbcTemplate.execute(sql);
+				}
+				catch (DataAccessException e) {
+					lastException = e;
+					return false;
+				}
+			}
+		}
+		return true;
+	}
+
+}

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/JdbcCommands.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/JdbcCommands.java
@@ -120,6 +120,7 @@ public class JdbcCommands {
 			jdbcTemplate.execute(prepareSql);
 		}
 		catch (DataAccessException e) {
+			log.error("Error during prepare sql", e);
 			lastException = e;
 			return false;
 		}
@@ -134,6 +135,7 @@ public class JdbcCommands {
 			jdbcTemplate.execute(runSql);
 		}
 		catch (DataAccessException e) {
+			log.error("Error during run sql", e);
 			lastException = e;
 			return false;
 		}
@@ -148,6 +150,7 @@ public class JdbcCommands {
 			jdbcTemplate.execute(cleanSql);
 		}
 		catch (DataAccessException e) {
+			log.error("Error during clean sql", e);
 			lastException = e;
 			return false;
 		}

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/LoadConfiguration.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/LoadConfiguration.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.module.gpfdist.sink.support;
+
+import java.util.List;
+
+public class LoadConfiguration {
+
+	private String table;
+
+	private String columns;
+
+	private ReadableTable externalTable;
+
+	private Mode mode;
+
+	private List<String> matchColumns;
+
+	private List<String> updateColumns;
+
+	private String updateCondition;
+
+	private List<String> sqlBefore;
+
+	private List<String> sqlAfter;
+
+	public LoadConfiguration() {
+		super();
+	}
+
+	public LoadConfiguration(String table, String columns, ReadableTable externalTable, Mode mode,
+			List<String> matchColumns, List<String> updateColumns, String updateCondition) {
+		this.table = table;
+		this.columns = columns;
+		this.externalTable = externalTable;
+		this.mode = mode;
+		this.matchColumns = matchColumns;
+		this.updateColumns = updateColumns;
+		this.updateCondition = updateCondition;
+	}
+
+	public String getTable() {
+		return table;
+	}
+
+	public void setTable(String table) {
+		this.table = table;
+	}
+
+	public String getColumns() {
+		return columns;
+	}
+
+	public void setColumns(String columns) {
+		this.columns = columns;
+	}
+
+	public ReadableTable getExternalTable() {
+		return externalTable;
+	}
+
+	public void setExternalTable(ReadableTable externalTable) {
+		this.externalTable = externalTable;
+	}
+
+	public Mode getMode() {
+		return mode;
+	}
+
+	public void setMode(Mode mode) {
+		this.mode = mode;
+	}
+
+	public List<String> getMatchColumns() {
+		return matchColumns;
+	}
+
+	public void setMatchColumns(List<String> matchColumns) {
+		this.matchColumns = matchColumns;
+	}
+
+	public List<String> getUpdateColumns() {
+		return updateColumns;
+	}
+
+	public void setUpdateColumns(List<String> updateColumns) {
+		this.updateColumns = updateColumns;
+	}
+
+	public String getUpdateCondition() {
+		return updateCondition;
+	}
+
+	public void setUpdateCondition(String updateCondition) {
+		this.updateCondition = updateCondition;
+	}
+
+	public List<String> getSqlBefore() {
+		return sqlBefore;
+	}
+
+	public void setSqlBefore(List<String> sqlBefore) {
+		this.sqlBefore = sqlBefore;
+	}
+
+	public List<String> getSqlAfter() {
+		return sqlAfter;
+	}
+
+	public void setSqlAfter(List<String> sqlAfter) {
+		this.sqlAfter = sqlAfter;
+	}
+
+}

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/LoadConfigurationFactoryBean.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/LoadConfigurationFactoryBean.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.module.gpfdist.sink.support;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.cloud.stream.module.gpfdist.sink.support.ControlFile.OutputMode;
+import org.springframework.util.StringUtils;
+
+public class LoadConfigurationFactoryBean implements FactoryBean<LoadConfiguration>, InitializingBean {
+
+	private ControlFile controlFile;
+
+	private String table;
+
+	private String columns;
+
+	private ReadableTable externalTable;
+
+	private Mode mode = Mode.INSERT;
+
+	private List<String> matchColumns;
+
+	private List<String> updateColumns;
+
+	private String updateCondition;
+
+	private List<String> sqlBefore;
+
+	private List<String> sqlAfter;
+
+	@Override
+	public void afterPropertiesSet() throws Exception {
+		if (controlFile != null) {
+			if (controlFile.getGploadOutputMode() != null) {
+				if (controlFile.getGploadOutputMode() == OutputMode.INSERT) {
+					mode = Mode.INSERT;
+				}
+				else if (controlFile.getGploadOutputMode() == OutputMode.UPDATE) {
+					mode = Mode.UPDATE;
+				}
+			}
+			if (StringUtils.hasText(controlFile.getGploadOutputTable())) {
+				table = controlFile.getGploadOutputTable();
+			}
+			if (controlFile.getGploadOutputMatchColumns() != null) {
+				matchColumns = controlFile.getGploadOutputMatchColumns();
+			}
+			if (controlFile.getGploadOutputUpdateColumns() != null) {
+				updateColumns = controlFile.getGploadOutputUpdateColumns();
+			}
+			if (StringUtils.hasText(controlFile.getGploadOutputUpdateCondition())) {
+				updateCondition = controlFile.getGploadOutputUpdateCondition();
+			}
+			if (!controlFile.getGploadSqlBefore().isEmpty()) {
+				sqlBefore = controlFile.getGploadSqlBefore();
+			}
+			if (!controlFile.getGploadSqlAfter().isEmpty()) {
+				sqlAfter = controlFile.getGploadSqlAfter();
+			}
+		}
+	}
+
+	@Override
+	public LoadConfiguration getObject() throws Exception {
+		LoadConfiguration loadConfiguration = new LoadConfiguration(table, columns, externalTable, mode, matchColumns,
+				updateColumns, updateCondition);
+		loadConfiguration.setSqlBefore(sqlBefore);
+		loadConfiguration.setSqlAfter(sqlAfter);
+		return loadConfiguration;
+	}
+
+	@Override
+	public Class<LoadConfiguration> getObjectType() {
+		return LoadConfiguration.class;
+	}
+
+	@Override
+	public boolean isSingleton() {
+		return false;
+	}
+
+	public void setControlFile(ControlFile controlFile) {
+		this.controlFile = controlFile;
+	}
+
+	public String getTable() {
+		return table;
+	}
+
+	public void setTable(String table) {
+		this.table = table;
+	}
+
+	public String getColumns() {
+		return columns;
+	}
+
+	public void setColumns(String columns) {
+		this.columns = columns;
+	}
+
+	public ReadableTable getExternalTable() {
+		return externalTable;
+	}
+
+	public void setExternalTable(ReadableTable externalTable) {
+		this.externalTable = externalTable;
+	}
+
+	public Mode getMode() {
+		return mode;
+	}
+
+	public void setMode(Mode mode) {
+		this.mode = mode;
+	}
+
+	public List<String> getMatchColumns() {
+		return matchColumns;
+	}
+
+	public void setMatchColumns(String[] matchColumns) {
+		this.matchColumns = Arrays.asList(matchColumns);
+	}
+
+	public List<String> getUpdateColumns() {
+		return updateColumns;
+	}
+
+	public void setUpdateColumns(String[] updateColumns) {
+		this.updateColumns = Arrays.asList(updateColumns);
+	}
+
+	public String getUpdateCondition() {
+		return updateCondition;
+	}
+
+	public void setUpdateCondition(String updateCondition) {
+		this.updateCondition = updateCondition;
+	}
+
+	public List<String> getSqlBefore() {
+		return sqlBefore;
+	}
+
+	public void setSqlBefore(List<String> sqlBefore) {
+		this.sqlBefore = sqlBefore;
+	}
+
+	public List<String> getSqlAfter() {
+		return sqlAfter;
+	}
+
+	public void setSqlAfter(List<String> sqlAfter) {
+		this.sqlAfter = sqlAfter;
+	}
+
+}

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/LoadFactoryBean.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/LoadFactoryBean.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.module.gpfdist.sink.support;
+
+import java.io.IOException;
+
+import javax.sql.DataSource;
+
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.util.Assert;
+
+/**
+ * FactoryBean for easy creation and configuration of {@link GreenplumLoad}
+ * instances.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class LoadFactoryBean implements FactoryBean<GreenplumLoad>, InitializingBean, DisposableBean {
+
+	private DataSource dataSource;
+
+	private LoadConfiguration loadConfiguration;
+
+	private JdbcTemplate jdbcTemplate;
+
+	@Override
+	public GreenplumLoad getObject() throws Exception {
+		return new DefaultGreenplumLoad(loadConfiguration, new DefaultLoadService(jdbcTemplate));
+	}
+
+	@Override
+	public Class<GreenplumLoad> getObjectType() {
+		return GreenplumLoad.class;
+	}
+
+	@Override
+	public boolean isSingleton() {
+		return true;
+	}
+
+	@Override
+	public void afterPropertiesSet() throws IOException {
+		Assert.notNull(dataSource, "DataSource must not be null.");
+		Assert.notNull(loadConfiguration, "Load configuration must not be null.");
+		jdbcTemplate = new JdbcTemplate(dataSource);
+	}
+
+	@Override
+	public void destroy() {
+	}
+
+	public void setDataSource(DataSource dataSource) {
+		this.dataSource = dataSource;
+	}
+
+	public void setLoadConfiguration(LoadConfiguration LoadConfiguration) {
+		this.loadConfiguration = LoadConfiguration;
+	}
+
+}

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/LoadService.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/LoadService.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.stream.module.gpfdist.sink.support;
+
+import org.springframework.cloud.stream.module.gpfdist.sink.support.LoadConfiguration;
+import org.springframework.cloud.stream.module.gpfdist.sink.support.RuntimeContext;
+
+public interface LoadService {
+
+	public void load(LoadConfiguration loadConfiguration);
+
+	public void load(LoadConfiguration loadConfiguration, RuntimeContext context);
+
+}

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/Mode.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/Mode.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.module.gpfdist.sink.support;
+
+public enum Mode {
+
+	INSERT, UPDATE
+
+}

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/NetworkUtils.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/NetworkUtils.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.stream.module.gpfdist.sink.support;
+
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.util.Enumeration;
+
+/**
+ * Various network utilities.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class NetworkUtils {
+
+	/**
+	 * Gets the main network address.
+	 *
+	 * @return network address, null if not found
+	 */
+	public static String getDefaultAddress() {
+		Enumeration<NetworkInterface> nets;
+		try {
+			nets = NetworkInterface.getNetworkInterfaces();
+		} catch (SocketException e) {
+			return null;
+		}
+		NetworkInterface netinf;
+		while (nets.hasMoreElements()) {
+			netinf = nets.nextElement();
+
+			Enumeration<InetAddress> addresses = netinf.getInetAddresses();
+
+			while (addresses.hasMoreElements()) {
+				InetAddress address = addresses.nextElement();
+				if (!address.isAnyLocalAddress() && !address.isMulticastAddress() && !(address instanceof Inet6Address)) {
+					return address.getHostAddress();
+				}
+			}
+		}
+		return null;
+	}
+
+	public static String getGPFDistUri(int port) {
+		return "gpfdist://" + getDefaultAddress() + ":" + port + "/data";
+	}
+
+}

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/ReadableTable.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/ReadableTable.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.stream.module.gpfdist.sink.support;
+
+/**
+ * Settings for readable external table.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class ReadableTable extends AbstractExternalTable {
+
+	// [LOG ERRORS INTO error_table]
+	private String logErrorsInto;
+
+	// SEGMENT REJECT LIMIT count
+	private Integer segmentRejectLimit;
+
+	// [ROWS | PERCENT]
+	private SegmentRejectType segmentRejectType;
+
+	// FORMAT 'TEXT|CVS' [( [HEADER]
+	private boolean formatHeader;
+
+	public boolean isFormatHeader() {
+		return formatHeader;
+	}
+
+	public void setFormatHeader(boolean formatHeader) {
+		this.formatHeader = formatHeader;
+	}
+
+	public String getLogErrorsInto() {
+		return logErrorsInto;
+	}
+
+	public void setLogErrorsInto(String logErrorsInto) {
+		this.logErrorsInto = logErrorsInto;
+	}
+
+	public Integer getSegmentRejectLimit() {
+		return segmentRejectLimit;
+	}
+
+	public void setSegmentRejectLimit(Integer segmentRejectLimit) {
+		this.segmentRejectLimit = segmentRejectLimit;
+	}
+
+	public SegmentRejectType getSegmentRejectType() {
+		return segmentRejectType;
+	}
+
+	public void setSegmentRejectType(SegmentRejectType segmentRejectType) {
+		this.segmentRejectType = segmentRejectType;
+	}
+
+}

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/ReadableTableFactoryBean.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/ReadableTableFactoryBean.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.module.gpfdist.sink.support;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.InitializingBean;
+
+/**
+ * @since 1.2
+ * @author Janne Valkealahti
+ * @author Gary Russell
+ */
+public class ReadableTableFactoryBean implements FactoryBean<ReadableTable>, InitializingBean {
+
+	private ControlFile controlFile;
+
+	private List<String> locations;
+
+	private String columns;
+
+	private String like;
+
+	private boolean keeptable;
+
+	private Format format = Format.TEXT;
+
+	private Character delimiter;
+
+	private String nullString;
+
+	private Character escape;
+
+	private Character quote;
+
+	private String[] forceQuote;
+
+	private String logErrorsInto;
+
+	private Integer segmentRejectLimit;
+
+	private SegmentRejectType segmentRejectType;
+
+	@Override
+	public void afterPropertiesSet() throws Exception {
+		if (controlFile != null) {
+			if (controlFile.getGploadInputDelimiter() != null) {
+				this.delimiter = controlFile.getGploadInputDelimiter();
+			}
+		}
+	}
+
+	@Override
+	public ReadableTable getObject() throws Exception {
+		ReadableTable w = new ReadableTable();
+		w.setLocations(locations);
+		w.setColumns(columns);
+		w.setLike(like);
+		w.setLogErrorsInto(logErrorsInto);
+		w.setSegmentRejectLimit(segmentRejectLimit);
+		w.setSegmentRejectType(segmentRejectType);
+
+		if (format == Format.TEXT) {
+			Character delim = delimiter != null ? delimiter : Character.valueOf('\t');
+			w.setTextFormat(delim, nullString, escape);
+		}
+		else if (format == Format.CSV) {
+			Character delim = delimiter != null ? delimiter : Character.valueOf(',');
+			w.setCsvFormat(quote, delim, nullString, forceQuote, escape);
+		}
+
+		return w;
+	}
+
+	@Override
+	public Class<ReadableTable> getObjectType() {
+		return ReadableTable.class;
+	}
+
+	@Override
+	public boolean isSingleton() {
+		return true;
+	}
+
+	public void setControlFile(ControlFile controlFile) {
+		this.controlFile = controlFile;
+	}
+
+	public Integer getSegmentRejectLimit() {
+		return segmentRejectLimit;
+	}
+
+	public void setSegmentRejectLimit(Integer segmentRejectLimit) {
+		this.segmentRejectLimit = segmentRejectLimit;
+	}
+
+	public SegmentRejectType getSegmentRejectType() {
+		return segmentRejectType;
+	}
+
+	public void setSegmentRejectType(SegmentRejectType segmentRejectType) {
+		this.segmentRejectType = segmentRejectType;
+	}
+
+	public String getLogErrorsInto() {
+		return logErrorsInto;
+	}
+
+	public void setLogErrorsInto(String logErrorsInto) {
+		this.logErrorsInto = logErrorsInto;
+	}
+
+	public Character getQuote() {
+		return quote;
+	}
+
+	public void setQuote(Character quote) {
+		this.quote = quote;
+	}
+
+	public String[] getForceQuote() {
+		return forceQuote;
+	}
+
+	public void setForceQuote(String[] forceQuote) {
+		this.forceQuote = Arrays.copyOf(forceQuote, forceQuote.length);
+	}
+
+	public Character getDelimiter() {
+		return delimiter;
+	}
+
+	public void setDelimiter(Character delimiter) {
+		this.delimiter = delimiter;
+	}
+
+	public String getNullString() {
+		return nullString;
+	}
+
+	public void setNullString(String nullString) {
+		this.nullString = nullString;
+	}
+
+	public Character getEscape() {
+		return escape;
+	}
+
+	public void setEscape(Character escape) {
+		this.escape = escape;
+	}
+
+	public List<String> getLocations() {
+		return locations;
+	}
+
+	public void setLocations(List<String> locations) {
+		this.locations = locations;
+	}
+
+	public String getColumns() {
+		return columns;
+	}
+
+	public void setColumns(String columns) {
+		this.columns = columns;
+	}
+
+	public String getLike() {
+		return like;
+	}
+
+	public void setLike(String like) {
+		this.like = like;
+	}
+
+	public boolean isKeeptable() {
+		return keeptable;
+	}
+
+	public void setKeeptable(boolean keeptable) {
+		this.keeptable = keeptable;
+	}
+
+	public Format getFormat() {
+		return format;
+	}
+
+	public void setFormat(Format format) {
+		this.format = format;
+	}
+
+}

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/RuntimeContext.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/RuntimeContext.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.stream.module.gpfdist.sink.support;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Runtime context for load operations.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class RuntimeContext {
+
+	private final List<String> locations = new ArrayList<String>();
+
+	public List<String> getLocations() {
+		return locations;
+	}
+
+	public void setLocations(List<String> locations) {
+		this.locations.clear();
+		this.locations.addAll(locations);
+	}
+
+	public void addLocation(String location) {
+		this.locations.add(location);
+	}
+
+}

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/SegmentRejectType.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/SegmentRejectType.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.stream.module.gpfdist.sink.support;
+
+public enum SegmentRejectType {
+
+	ROWS, PERCENT
+
+}

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/SqlUtils.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/SqlUtils.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.module.gpfdist.sink.support;
+
+import java.util.List;
+
+import org.springframework.util.StringUtils;
+
+public abstract class SqlUtils {
+
+	public static String createExternalReadableTable(LoadConfiguration config, String prefix,
+			List<String> overrideLocations) {
+
+		// TODO: this function needs a cleanup
+		StringBuilder buf = new StringBuilder();
+
+		// unique table name
+		String name = config.getTable() + "_ext_" + prefix;
+		buf.append("CREATE READABLE EXTERNAL TABLE ");
+		buf.append(name);
+		buf.append(" ( ");
+
+		// column types or like
+		ReadableTable externalTable = config.getExternalTable();
+		if (externalTable.getLike() != null) {
+			buf.append("LIKE ");
+			buf.append(config.getTable());
+		}
+		else if (StringUtils.hasText(externalTable.getColumns())) {
+			buf.append(externalTable.getColumns());
+		}
+		else {
+			buf.append("LIKE ");
+			buf.append(config.getTable());
+		}
+		buf.append(" ) ");
+
+		// locations
+		buf.append("LOCATION(");
+		if (overrideLocations != null && !overrideLocations.isEmpty()) {
+			buf.append(createLocationString(overrideLocations.toArray(new String[0])));
+		}
+		else {
+			buf.append(createLocationString(externalTable.getLocations().toArray(new String[0])));
+		}
+		buf.append(") ");
+
+		// format type
+		if (externalTable.getFormat() == Format.TEXT) {
+			buf.append("FORMAT 'TEXT'");
+		}
+		else {
+			buf.append("FORMAT 'CSV'");
+		}
+
+		// format parameters
+		buf.append(" ( ");
+		buf.append("DELIMITER '");
+		if (externalTable.getDelimiter() != null) {
+			buf.append(unicodeEscaped(externalTable.getDelimiter().charValue()));
+		}
+		else {
+			buf.append("|");
+		}
+		buf.append("'");
+
+		if (externalTable.getNullString() != null) {
+			buf.append(" NULL '");
+			buf.append(externalTable.getNullString());
+			buf.append("'");
+		}
+
+		if (externalTable.getEscape() != null) {
+			buf.append(" ESCAPE '");
+			buf.append(externalTable.getEscape());
+			buf.append("'");
+		}
+
+		if (externalTable.getQuote() != null) {
+			buf.append(" QUOTE '");
+			buf.append(externalTable.getQuote());
+			buf.append("'");
+		}
+
+		if (externalTable.getForceQuote() != null) {
+			buf.append(" FORCE QUOTE ");
+			buf.append(StringUtils.arrayToCommaDelimitedString(externalTable.getForceQuote()));
+		}
+
+		buf.append(" )");
+
+		if (externalTable.getEncoding() != null) {
+			buf.append(" ENCODING '");
+			buf.append(externalTable.getEncoding());
+			buf.append("'");
+		}
+
+		if (externalTable.getSegmentRejectLimit() != null && externalTable.getSegmentRejectType() != null) {
+			if (externalTable.getLogErrorsInto() != null) {
+				buf.append(" LOG ERRORS INTO ");
+				buf.append(externalTable.getLogErrorsInto());
+			}
+			buf.append(" SEGMENT REJECT LIMIT ");
+			buf.append(externalTable.getSegmentRejectLimit());
+			buf.append(" ");
+			buf.append(externalTable.getSegmentRejectType());
+		}
+
+		return buf.toString();
+	}
+
+	/**
+	 *
+	 * @param config the load configuration
+	 * @param prefix the prefix
+	 * @return the drop DDL
+	 */
+	public static String dropExternalReadableTable(LoadConfiguration config, String prefix) {
+		StringBuilder b = new StringBuilder();
+
+		// unique table name
+		String name = config.getTable() + "_ext_" + prefix;
+
+		b.append("DROP EXTERNAL TABLE ");
+		b.append(name);
+
+		return b.toString();
+
+	}
+
+	/**
+	 * Builds sql clause to load data into a database.
+	 *
+	 * @param config
+	 *            Load configuration.
+	 * @param prefix
+	 *            Prefix for temporary resources.
+	 * @return
+	 *            the load DDL
+	 */
+	public static String load(LoadConfiguration config, String prefix) {
+		if (config.getMode() == Mode.INSERT) {
+			return loadInsert(config, prefix);
+		}
+		else if (config.getMode() == Mode.UPDATE) {
+			return loadUpdate(config, prefix);
+		}
+		throw new IllegalArgumentException("Unsupported mode " + config.getMode());
+	}
+
+	private static String loadInsert(LoadConfiguration config, String prefix) {
+		StringBuilder b = new StringBuilder();
+
+		String name = config.getTable() + "_ext_" + prefix;
+
+		b.append("INSERT INTO ");
+		b.append(config.getTable());
+		b.append(" SELECT ");
+		if (StringUtils.hasText(config.getColumns())) {
+			b.append(config.getColumns());
+		}
+		else {
+			b.append("*");
+		}
+		b.append(" FROM ");
+		b.append(name);
+
+		return b.toString();
+	}
+
+	private static String loadUpdate(LoadConfiguration config, String prefix) {
+		StringBuilder b = new StringBuilder();
+		String name = config.getTable() + "_ext_" + prefix;
+		b.append("UPDATE ");
+		b.append(config.getTable());
+		b.append(" into_table set ");
+
+		for (int i = 0; i < config.getUpdateColumns().size(); i++) {
+			b.append(config.getUpdateColumns().get(i) + "=from_table." + config.getUpdateColumns().get(i));
+			if (i + 1 < config.getUpdateColumns().size()) {
+				b.append(", ");
+			}
+		}
+
+		b.append(" FROM ");
+		b.append(name);
+		b.append(" from_table where ");
+
+		for (int i = 0; i < config.getMatchColumns().size(); i++) {
+			b.append("into_table." + config.getMatchColumns().get(i) + "=from_table." + config.getMatchColumns().get(i));
+			if (i + 1 < config.getMatchColumns().size()) {
+				b.append(" and ");
+			}
+		}
+
+		if (StringUtils.hasText(config.getUpdateCondition())) {
+			b.append(" and " + config.getUpdateCondition());
+		}
+
+		return b.toString();
+	}
+
+	/**
+	 * Converts string array to greenplum friendly string. From new
+	 * String[]{"foo","jee"} we get "'foo',jee'".
+	 *
+	 * @param strings
+	 *            String array to explode
+	 * @return Comma delimited string with values encapsulated with
+	 *         apostropheres. ‘'
+	 */
+	public static String createLocationString(String[] strings) {
+		StringBuilder locString = new StringBuilder();
+		for (int i = 0; i < strings.length; i++) {
+			String string = strings[i];
+			locString.append("'");
+			locString.append(string);
+			locString.append("'");
+			if (i < strings.length - 1) {
+				locString.append(",");
+			}
+		}
+		return locString.toString();
+	}
+
+	private static String unicodeEscaped(char ch) {
+		if (ch < 0x10) {
+			return "\\u000" + Integer.toHexString(ch);
+		}
+		else if (ch < 0x100) {
+			return "\\u00" + Integer.toHexString(ch);
+		}
+		else if (ch < 0x1000) {
+			return "\\u0" + Integer.toHexString(ch);
+		}
+		return "\\u" + Integer.toHexString(ch);
+	}
+
+}

--- a/gpfdist-sink/src/test/java/org/springframework/cloud/stream/module/gpfdist/sink/AbstractLoadTests.java
+++ b/gpfdist-sink/src/test/java/org/springframework/cloud/stream/module/gpfdist/sink/AbstractLoadTests.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.module.gpfdist.sink;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.commons.dbcp.BasicDataSource;
+import org.junit.After;
+import org.junit.Before;
+import org.reactivestreams.Processor;
+import org.springframework.cloud.stream.module.gpfdist.sink.support.Format;
+import org.springframework.cloud.stream.module.gpfdist.sink.support.LoadConfiguration;
+import org.springframework.cloud.stream.module.gpfdist.sink.support.LoadFactoryBean;
+import org.springframework.cloud.stream.module.gpfdist.sink.support.NetworkUtils;
+import org.springframework.cloud.stream.module.gpfdist.sink.support.ReadableTableFactoryBean;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import reactor.Environment;
+import reactor.core.processor.RingBufferProcessor;
+import reactor.io.buffer.Buffer;
+
+/**
+ * Base integration support for using local protocol listener.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public abstract class AbstractLoadTests {
+
+	protected AnnotationConfigApplicationContext context;
+
+	protected Processor<Buffer, Buffer> processor;
+
+	private GpfdistServer server;
+
+	static class CommonConfig {
+
+		@Bean
+		public LoadFactoryBean greenplumLoad(LoadConfiguration loadConfiguration) {
+			LoadFactoryBean factory = new LoadFactoryBean();
+			factory.setLoadConfiguration(loadConfiguration);
+			factory.setDataSource(dataSource());
+			return factory;
+		}
+
+		@Bean
+		public ReadableTableFactoryBean greenplumReadableTable() {
+			ReadableTableFactoryBean factory = new ReadableTableFactoryBean();
+			factory.setLocations(Arrays.asList(NetworkUtils.getGPFDistUri(8080)));
+			factory.setFormat(Format.TEXT);
+			return factory;
+		}
+
+		@Bean
+		public JdbcTemplate jdbcTemplate() {
+			return new JdbcTemplate(dataSource());
+		}
+
+		@Bean
+		public BasicDataSource dataSource() {
+			BasicDataSource dataSource = new BasicDataSource();
+			dataSource.setDriverClassName("org.postgresql.Driver");
+			dataSource.setUrl("jdbc:postgresql://mdw/gpadmin");
+			dataSource.setUsername("gpadmin");
+			dataSource.setPassword("gpadmin");
+			return dataSource;
+		}
+
+	}
+
+	protected void broadcastData(List<String> data) {
+		for (String d : data) {
+			processor.onNext(Buffer.wrap(d));
+		}
+	}
+
+	@Before
+	public void setup() throws Exception {
+		Environment.initializeIfEmpty().assignErrorJournal();
+		processor = RingBufferProcessor.create(false);
+		server = new GpfdistServer(processor, 8080, 1, 1, 1, 10);
+		server.start();
+		context = new AnnotationConfigApplicationContext();
+	}
+
+	@After
+	public void clean() throws Exception {
+		server.stop();
+		context.close();
+		context = null;
+		server = null;
+	}
+
+}

--- a/gpfdist-sink/src/test/java/org/springframework/cloud/stream/module/gpfdist/sink/LoadIT.java
+++ b/gpfdist-sink/src/test/java/org/springframework/cloud/stream/module/gpfdist/sink/LoadIT.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.module.gpfdist.sink;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+import org.springframework.cloud.stream.module.gpfdist.sink.support.GreenplumLoad;
+import org.springframework.cloud.stream.module.gpfdist.sink.support.LoadConfigurationFactoryBean;
+import org.springframework.cloud.stream.module.gpfdist.sink.support.Mode;
+import org.springframework.cloud.stream.module.gpfdist.sink.support.ReadableTable;
+import org.springframework.context.annotation.Bean;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+public class LoadIT extends AbstractLoadTests {
+
+	@Test
+	public void testInsert() {
+		context.register(Config1.class, CommonConfig.class);
+		context.refresh();
+		JdbcTemplate template = context.getBean(JdbcTemplate.class);
+		String drop = "DROP TABLE IF EXISTS AbstractLoadTests;";
+		String create = "CREATE TABLE AbstractLoadTests (data text);";
+		template.execute(drop);
+		template.execute(create);
+
+		List<String> data = new ArrayList<String>();
+		for (int i = 0; i < 10; i++) {
+			data.add("DATA" + i + "\n");
+		}
+
+		broadcastData(data);
+
+		GreenplumLoad greenplumLoad = context.getBean(GreenplumLoad.class);
+		greenplumLoad.load();
+
+		List<Map<String, Object>> queryForList = template.queryForList("SELECT * from AbstractLoadTests;");
+		assertThat(queryForList, notNullValue());
+		assertThat(queryForList.size(), is(10));
+		List<String> queryData = new ArrayList<String>();
+		for (int i = 0; i < 10; i++) {
+			queryData.add((String) queryForList.get(i).get("data"));
+		}
+		assertThat(
+				queryData,
+				containsInAnyOrder("DATA0", "DATA1", "DATA2", "DATA3", "DATA4", "DATA5", "DATA6", "DATA7", "DATA8",
+						"DATA9"));
+	}
+
+	@Test
+	public void testUpdate() {
+		context.register(Config2.class, CommonConfig.class);
+		context.refresh();
+		JdbcTemplate template = context.getBean(JdbcTemplate.class);
+		String drop = "DROP TABLE IF EXISTS AbstractLoadTests;";
+		String create = "CREATE TABLE AbstractLoadTests (col1 text, col2 text);";
+		template.execute(drop);
+		template.execute(create);
+
+		List<String> data = new ArrayList<String>();
+		for (int i = 0; i < 10; i++) {
+			template.execute("insert into AbstractLoadTests values('DATA" + i + "', 'DATA');");
+			data.add("DATA" + i + "\tDATA" + i + "\n");
+		}
+
+		broadcastData(data);
+
+		GreenplumLoad greenplumLoad = context.getBean(GreenplumLoad.class);
+		greenplumLoad.load();
+
+		List<Map<String, Object>> queryForList = template.queryForList("SELECT * from AbstractLoadTests;");
+		assertThat(queryForList, notNullValue());
+		assertThat(queryForList.size(), is(10));
+		for (int i = 0; i < 10; i++) {
+			assertThat(queryForList.get(i).get("col2"), is(queryForList.get(i).get("col1")));
+		}
+	}
+
+	@Test
+	public void testUpdateMultiColumns() {
+		context.register(Config3.class, CommonConfig.class);
+		context.refresh();
+		JdbcTemplate template = context.getBean(JdbcTemplate.class);
+		String drop = "DROP TABLE IF EXISTS AbstractLoadTests;";
+		String create = "CREATE TABLE AbstractLoadTests (col1 text, col2 text, col3 text);";
+		template.execute(drop);
+		template.execute(create);
+
+		List<String> data = new ArrayList<String>();
+		for (int i = 0; i < 10; i++) {
+			template.execute("insert into AbstractLoadTests values('DATA" + i + "', 'DATA', 'DATA');");
+			data.add("DATA" + i + "\tDATA" + i + "\tDATA" + i + "\n");
+		}
+
+		broadcastData(data);
+
+		GreenplumLoad greenplumLoad = context.getBean(GreenplumLoad.class);
+		greenplumLoad.load();
+
+		List<Map<String, Object>> queryForList = template.queryForList("SELECT * from AbstractLoadTests;");
+		assertThat(queryForList, notNullValue());
+		assertThat(queryForList.size(), is(10));
+		for (int i = 0; i < 10; i++) {
+			assertThat(queryForList.get(i).get("col2"), is(queryForList.get(i).get("col1")));
+			assertThat(queryForList.get(i).get("col3"), is(queryForList.get(i).get("col1")));
+		}
+	}
+
+	static class Config1 {
+
+		@Bean
+		public LoadConfigurationFactoryBean greenplumLoadConfiguration(ReadableTable externalTable) {
+			LoadConfigurationFactoryBean factory = new LoadConfigurationFactoryBean();
+			factory.setTable("AbstractLoadTests");
+			factory.setExternalTable(externalTable);
+			factory.setMode(Mode.INSERT);
+			return factory;
+		}
+
+	}
+
+	static class Config2 {
+
+		@Bean
+		public LoadConfigurationFactoryBean greenplumLoadConfiguration(ReadableTable externalTable) {
+			LoadConfigurationFactoryBean factory = new LoadConfigurationFactoryBean();
+			factory.setTable("AbstractLoadTests");
+			factory.setExternalTable(externalTable);
+			factory.setMode(Mode.UPDATE);
+			factory.setUpdateColumns(new String[] { "col2" });
+			factory.setMatchColumns(new String[] { "col1" });
+			return factory;
+		}
+
+	}
+
+	static class Config3 {
+
+		@Bean
+		public LoadConfigurationFactoryBean greenplumLoadConfiguration(ReadableTable externalTable) {
+			LoadConfigurationFactoryBean factory = new LoadConfigurationFactoryBean();
+			factory.setTable("AbstractLoadTests");
+			factory.setExternalTable(externalTable);
+			factory.setMode(Mode.UPDATE);
+			factory.setUpdateColumns(new String[] { "col2", "col3" });
+			factory.setMatchColumns(new String[] { "col1" });
+			return factory;
+		}
+
+	}
+
+}

--- a/gpfdist-sink/src/test/java/org/springframework/cloud/stream/module/gpfdist/sink/TestListenAddress.java
+++ b/gpfdist-sink/src/test/java/org/springframework/cloud/stream/module/gpfdist/sink/TestListenAddress.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.module.gpfdist.sink;
+
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+import java.net.InetSocketAddress;
+
+import org.junit.Test;
+
+import reactor.Environment;
+import reactor.fn.Function;
+import reactor.io.buffer.Buffer;
+import reactor.io.net.NetStreams;
+import reactor.io.net.Spec.HttpServerSpec;
+import reactor.io.net.http.HttpServer;
+
+public class TestListenAddress {
+
+	@Test
+	public void testBindZero() throws Exception {
+		Environment.initializeIfEmpty().assignErrorJournal();
+
+		HttpServer<Buffer, Buffer> httpServer = NetStreams
+				.httpServer(new Function<HttpServerSpec<Buffer, Buffer>, HttpServerSpec<Buffer, Buffer>>() {
+
+					@Override
+					public HttpServerSpec<Buffer, Buffer> apply(HttpServerSpec<Buffer, Buffer> server) {
+						return server
+								.codec(new GpfdistCodec())
+								.listen(0);
+					}
+				});
+		httpServer.start().awaitSuccess();
+		InetSocketAddress address = httpServer.getListenAddress();
+		assertThat(address, notNullValue());
+		assertThat(address.getPort(), not(0));
+		httpServer.shutdown();
+	}
+
+}

--- a/gpfdist-sink/src/test/java/org/springframework/cloud/stream/module/gpfdist/sink/TestUtils.java
+++ b/gpfdist-sink/src/test/java/org/springframework/cloud/stream/module/gpfdist/sink/TestUtils.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.module.gpfdist.sink;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * Utils for tests.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class TestUtils {
+
+	@SuppressWarnings("unchecked")
+	public static <T> T readField(String name, Object target) throws Exception {
+		Field field = null;
+		Class<?> clazz = target.getClass();
+		do {
+			try {
+				field = clazz.getDeclaredField(name);
+			} catch (Exception ex) {
+			}
+
+			clazz = clazz.getSuperclass();
+		} while (field == null && !clazz.equals(Object.class));
+
+		if (field == null)
+			throw new IllegalArgumentException("Cannot find field '" + name + "' in the class hierarchy of "
+					+ target.getClass());
+		field.setAccessible(true);
+		return (T) field.get(target);
+	}
+
+	@SuppressWarnings("unchecked")
+	public static <T> T callMethod(String name, Object target) throws Exception {
+		Class<?> clazz = target.getClass();
+		Method method = ReflectionUtils.findMethod(clazz, name);
+
+		if (method == null)
+			throw new IllegalArgumentException("Cannot find method '" + method + "' in the class hierarchy of "
+					+ target.getClass());
+		method.setAccessible(true);
+		return (T) ReflectionUtils.invokeMethod(method, target);
+	}
+
+	public static void setField(String name, Object target, Object value) throws Exception {
+		Field field = null;
+		Class<?> clazz = target.getClass();
+		do {
+			try {
+				field = clazz.getDeclaredField(name);
+			} catch (Exception ex) {
+			}
+
+			clazz = clazz.getSuperclass();
+		} while (field == null && !clazz.equals(Object.class));
+
+		if (field == null)
+			throw new IllegalArgumentException("Cannot find field '" + name + "' in the class hierarchy of "
+					+ target.getClass());
+		field.setAccessible(true);
+		field.set(target, value);
+	}
+
+	@SuppressWarnings("unchecked")
+	public static <T> T callMethod(String name, Object target, Object[] args, Class<?>[] argsTypes) throws Exception {
+		Class<?> clazz = target.getClass();
+		Method method = ReflectionUtils.findMethod(clazz, name, argsTypes);
+
+		if (method == null)
+			throw new IllegalArgumentException("Cannot find method '" + method + "' in the class hierarchy of "
+					+ target.getClass());
+		method.setAccessible(true);
+		return (T) ReflectionUtils.invokeMethod(method, target, args);
+	}
+
+}

--- a/gpfdist-sink/src/test/java/org/springframework/cloud/stream/module/gpfdist/sink/support/ControlFileTests.java
+++ b/gpfdist-sink/src/test/java/org/springframework/cloud/stream/module/gpfdist/sink/support/ControlFileTests.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.module.gpfdist.sink.support;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import org.junit.After;
+import org.junit.Test;
+import org.springframework.cloud.stream.module.gpfdist.sink.support.ControlFile;
+import org.springframework.cloud.stream.module.gpfdist.sink.support.ControlFileFactoryBean;
+import org.springframework.cloud.stream.module.gpfdist.sink.support.ControlFile.OutputMode;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.io.ClassPathResource;
+
+public class ControlFileTests {
+
+	private AnnotationConfigApplicationContext context;
+
+	@Test
+	public void testLoadFromFactory() {
+		context = new AnnotationConfigApplicationContext();
+		context.register(Config1.class);
+		context.refresh();
+
+		ControlFile cf = context.getBean(ControlFile.class);
+		assertThat(cf.getGploadOutputTable(), is("test"));
+		assertThat(cf.getGploadInputDelimiter(), is(','));
+		assertThat(cf.getDatabase(), is("gpadmin"));
+		assertThat(cf.getUser(), is("gpadmin"));
+		assertThat(cf.getHost(), is("mdw.example.org"));
+		assertThat(cf.getPort(), is(5432));
+		assertThat(cf.getPassword(), nullValue());
+
+		assertThat(cf.getGploadOutputMode(), is(OutputMode.UPDATE));
+
+		assertThat(cf.getGploadOutputMatchColumns(), notNullValue());
+		assertThat(cf.getGploadOutputMatchColumns().size(), is(2));
+		assertThat(cf.getGploadOutputMatchColumns().get(0), is("col11"));
+		assertThat(cf.getGploadOutputMatchColumns().get(1), is("col12"));
+
+		assertThat(cf.getGploadOutputUpdateColumns(), notNullValue());
+		assertThat(cf.getGploadOutputUpdateColumns().size(), is(2));
+		assertThat(cf.getGploadOutputUpdateColumns().get(0), is("col21"));
+		assertThat(cf.getGploadOutputUpdateColumns().get(1), is("col22"));
+		assertThat(cf.getGploadOutputUpdateCondition(), is("condition"));
+
+		assertThat(cf.getGploadSqlBefore().get(0), is("select 1 as before"));
+		assertThat(cf.getGploadSqlBefore().get(1), is("select 2 as before"));
+		assertThat(cf.getGploadSqlAfter().get(0), is("select 1 as after"));
+		assertThat(cf.getGploadSqlAfter().get(1), is("select 2 as after"));
+	}
+
+	static class Config1 {
+
+		@Bean
+		public ControlFileFactoryBean controlFile() {
+			ControlFileFactoryBean f = new ControlFileFactoryBean();
+			f.setControlFileResource(new ClassPathResource("test.yml"));
+			return f;
+		}
+
+	}
+
+	@After
+	public void clean() {
+		context.close();
+		context = null;
+	}
+
+}

--- a/gpfdist-sink/src/test/java/org/springframework/cloud/stream/module/gpfdist/sink/support/LoadConfigurationFactoryBeanTests.java
+++ b/gpfdist-sink/src/test/java/org/springframework/cloud/stream/module/gpfdist/sink/support/LoadConfigurationFactoryBeanTests.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.module.gpfdist.sink.support;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.springframework.cloud.stream.module.gpfdist.sink.support.LoadConfigurationFactoryBean;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+/**
+ * Tests for {@link LoadConfigurationFactoryBean}.
+ *
+ * @author Janne Valkealahti
+ */
+public class LoadConfigurationFactoryBeanTests {
+
+	@Test
+	public void testListValuesToColumns() {
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
+				"LoadConfigurationFactoryBeanTests1.xml");
+		LoadConfigurationFactoryBean factoryBean = context.getBean("&greenplumLoadConfiguration",
+				LoadConfigurationFactoryBean.class);
+		assertThat(factoryBean.getUpdateColumns().size(), is(2));
+		assertThat(factoryBean.getMatchColumns().size(), is(2));
+		context.close();
+	}
+
+}

--- a/gpfdist-sink/src/test/resources/LoadConfigurationFactoryBeanTests1.xml
+++ b/gpfdist-sink/src/test/resources/LoadConfigurationFactoryBeanTests1.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans:beans xmlns="http://www.springframework.org/schema/integration"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:beans="http://www.springframework.org/schema/beans"
+	xmlns:int-groovy="http://www.springframework.org/schema/integration/groovy"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans
+		http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration
+		http://www.springframework.org/schema/integration/spring-integration.xsd">
+
+		<beans:bean id="greenplumLoadConfiguration" class="org.springframework.cloud.stream.module.gpfdist.sink.support.LoadConfigurationFactoryBean">
+				<beans:property name="updateColumns" value="col1,col2" />
+				<beans:property name="matchColumns" value="col1,col2" />
+		</beans:bean>
+
+</beans:beans>

--- a/gpfdist-sink/src/test/resources/test.yml
+++ b/gpfdist-sink/src/test/resources/test.yml
@@ -1,0 +1,34 @@
+VERSION: 1.0.0.1
+DATABASE: gpadmin
+USER: gpadmin
+HOST: mdw.example.org
+PORT: 5432
+GPLOAD:
+    INPUT:
+     - SOURCE:
+          PORT: 8100
+          FILE: [ /home/gpadmin/test/data/* ]
+     - COLUMNS:
+         - "id":
+         - "name":
+     - FORMAT: text
+     - DELIMITER: ','
+     - ENCODING: 'UTF8'
+     - NULL_AS: ''
+     - ERROR_LIMIT: 100000
+     - ERROR_TABLE: test_err
+    OUTPUT:
+     - TABLE: test
+     - MODE: UPDATE
+     - MATCH_COLUMNS:
+         - col11
+         - col12
+     - UPDATE_COLUMNS:
+         - col21
+         - col22
+     - UPDATE_CONDITION: 'condition'
+    SQL:
+     - BEFORE: "select 1 as before"
+     - BEFORE: "select 2 as before"
+     - AFTER: "select 1 as after"
+     - AFTER: "select 2 as after"

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
 		<module>file-sink</module>
 		<module>ftp-sink</module>
 		<module>gemfire-sink</module>
+		<module>gpfdist-sink</module>
 		<module>hdfs-dataset-sink</module>
 		<module>hdfs-sink</module>
 		<module>jdbc-sink</module>


### PR DESCRIPTION
- Port code and tests as it from xd module into
  a boot app.
- Integration tests are disabled by default, enable with
  `-DskipITs=false`.
- Fixes #74 

From psql:

```
gpadmin=# create table ticktock (date text, time text);
```

Simple test assuming gpdb master host is `mdw`

```
# java -jar time-source/target/time-source-1.0.0.BUILD-SNAPSHOT-exec.jar --server.port=8081 --spring.cloud.stream.bindings.output=xxx
# java -jar gpfdist-sink/target/gpfdist-sink-1.0.0.BUILD-SNAPSHOT-exec.jar --server.port=8082 --spring.cloud.stream.bindings.input=xxx --dbHost=mdw --table=ticktock --batchTime=1 --batchPeriod=1 --flushCount=2 --flushTime=2 --columnDelimiter=" "
```

Check results:

```
gpadmin=# select count(*) from ticktock;
 count 
-------
   152
(1 row)
```
