### PR TITLE
Some fixes and polishing

### DIFF
--- a/cassandra-sink/src/test/java/org/springframework/cloud/stream/module/cassandra/sink/CassandraSinkIntegrationTests.java
+++ b/cassandra-sink/src/test/java/org/springframework/cloud/stream/module/cassandra/sink/CassandraSinkIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,6 @@ import org.cassandraunit.spring.EmbeddedCassandra;
 import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -63,7 +62,8 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 				CassandraUnitDependencyInjectionIntegrationTestExecutionListener.class })
 @SpringApplicationConfiguration(CassandraSinkApplication.class)
 @IntegrationTest({"spring.cassandra.keyspace=" + CassandraSinkIntegrationTests.CASSANDRA_KEYSPACE,
-		"spring.cassandra.createKeyspace=true"})
+		"spring.cassandra.createKeyspace=true",
+		"server.port=-1"})
 @EmbeddedCassandra(configuration = EmbeddedCassandraServerHelper.CASSANDRA_RNDPORT_YML_FILE, timeout = 60000)
 @DirtiesContext
 public abstract class CassandraSinkIntegrationTests {

--- a/cassandra-sink/src/test/java/org/springframework/cloud/stream/module/cassandra/sink/CassandraSinkPropertiesTests.java
+++ b/cassandra-sink/src/test/java/org/springframework/cloud/stream/module/cassandra/sink/CassandraSinkPropertiesTests.java
@@ -15,6 +15,11 @@
 
 package org.springframework.cloud.stream.module.cassandra.sink;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.Test;
+
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.EnvironmentTestUtils;
 import org.springframework.cassandra.core.ConsistencyLevel;
@@ -27,11 +32,6 @@ import org.springframework.expression.Expression;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.integration.cassandra.outbound.CassandraMessageHandler;
 import org.springframework.integration.config.EnableIntegration;
-
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
-
-import org.junit.Test;
 
 /**
  * @author Thomas Risberg
@@ -46,6 +46,7 @@ public class CassandraSinkPropertiesTests {
 		context.refresh();
 		CassandraSinkProperties properties = context.getBean(CassandraSinkProperties.class);
 		assertThat(properties.getConsistencyLevel(), equalTo(ConsistencyLevel.LOCAL_QUOROM));
+		context.close();
 	}
 
 	@Test
@@ -56,6 +57,7 @@ public class CassandraSinkPropertiesTests {
 		context.refresh();
 		CassandraSinkProperties properties = context.getBean(CassandraSinkProperties.class);
 		assertThat(properties.getRetryPolicy(), equalTo(RetryPolicy.DOWNGRADING_CONSISTENCY));
+		context.close();
 	}
 
 	@Test
@@ -66,6 +68,7 @@ public class CassandraSinkPropertiesTests {
 		context.refresh();
 		CassandraSinkProperties properties = context.getBean(CassandraSinkProperties.class);
 		assertThat(properties.getTtl(), equalTo(1000));
+		context.close();
 	}
 
 	@Test
@@ -76,6 +79,7 @@ public class CassandraSinkPropertiesTests {
 		context.refresh();
 		CassandraSinkProperties properties = context.getBean(CassandraSinkProperties.class);
 		assertThat(properties.getQueryType(), equalTo(CassandraMessageHandler.Type.UPDATE));
+		context.close();
 	}
 
 	@Test
@@ -87,6 +91,7 @@ public class CassandraSinkPropertiesTests {
 		context.refresh();
 		CassandraSinkProperties properties = context.getBean(CassandraSinkProperties.class);
 		assertThat(properties.getIngestQuery(), equalTo(query));
+		context.close();
 	}
 
 	@Test
@@ -99,6 +104,7 @@ public class CassandraSinkPropertiesTests {
 		context.refresh();
 		CassandraSinkProperties properties = context.getBean(CassandraSinkProperties.class);
 		assertThat(properties.getStatementExpression().getExpressionString(), equalTo(expression.getExpressionString()));
+		context.close();
 	}
 
 	@Configuration

--- a/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/SourcePayloadProperties.java
+++ b/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/SourcePayloadProperties.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016 the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.module;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.expression.Expression;
+import org.springframework.expression.common.LiteralExpression;
+
+/**
+ * @author Artem Bilan
+ */
+@ConfigurationProperties
+public class SourcePayloadProperties {
+
+	/**
+	 * The expression for the payload of the Source module.
+	 */
+	private Expression payload = new LiteralExpression("");
+
+	public Expression getPayload() {
+		return this.payload;
+	}
+
+	public void setPayload(Expression payload) {
+		this.payload = payload;
+	}
+
+}

--- a/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/trigger/TriggerProperties.java
+++ b/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/trigger/TriggerProperties.java
@@ -24,8 +24,6 @@ import javax.validation.constraints.AssertFalse;
 import javax.validation.constraints.Min;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.expression.Expression;
-import org.springframework.expression.common.LiteralExpression;
 import org.springframework.util.StringUtils;
 
 /**
@@ -64,8 +62,6 @@ public class TriggerProperties {
 	 * Cron expression value for the Cron Trigger.
 	 */
 	private String cron;
-
-	private Expression payload = new LiteralExpression("");
 
 	@Min(0)
 	public int getInitialDelay() {
@@ -131,14 +127,6 @@ public class TriggerProperties {
 	}
 	public void setDateFormat(String dateFormat) {
 		this.dateFormat = dateFormat;
-	}
-
-	public Expression getPayload() {
-		return this.payload;
-	}
-
-	public void setPayload(Expression payload) {
-		this.payload = payload;
 	}
 
 	@AssertFalse

--- a/common/spring-cloud-stream-modules-common-configuration/src/test/java/org/springframework/cloud/stream/module/sftp/SftpSessionFactoryPropertiesTests.java
+++ b/common/spring-cloud-stream-modules-common-configuration/src/test/java/org/springframework/cloud/stream/module/sftp/SftpSessionFactoryPropertiesTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -23,6 +23,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import org.junit.Assume;
 import org.junit.Test;
 
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -35,6 +36,7 @@ import org.springframework.validation.FieldError;
 /**
  * @author David Turanski
  * @author Gary Russell
+ * @author Artem Bilan
  */
 public class SftpSessionFactoryPropertiesTests {
 
@@ -110,12 +112,11 @@ public class SftpSessionFactoryPropertiesTests {
 
 	@Test
 	public void noPropertiesThrowsMeaningfulException() {
-		try {
-			AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+		Assume.assumeFalse(System.getProperty("os.name").startsWith("Windows"));
+		try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext()) {
 			context.register(Conf.class);
 			context.refresh();
 			fail("should throw exception");
-			context.close();
 		}
 		catch (Exception e) {
 			assertThat(e.getCause(), instanceOf(BindException.class));
@@ -129,5 +130,7 @@ public class SftpSessionFactoryPropertiesTests {
 	@Configuration
 	@EnableConfigurationProperties(SftpSessionFactoryProperties.class)
 	static class Conf {
+
 	}
+
 }

--- a/file-sink/src/test/java/org/springframework/cloud/stream/module/file/sink/FileSinkTests.java
+++ b/file-sink/src/test/java/org/springframework/cloud/stream/module/file/sink/FileSinkTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,10 +27,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.IntegrationTest;
 import org.springframework.boot.test.SpringApplicationConfiguration;
-import org.springframework.boot.test.WebIntegrationTest;
 import org.springframework.cloud.stream.messaging.Sink;
-import org.springframework.cloud.stream.module.file.sink.FileSinkApplication;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -38,10 +37,10 @@ import org.springframework.util.FileCopyUtils;
 
 /**
  * @author Mark Fisher
+ * @author Artem Bilan
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = FileSinkApplication.class)
-@WebIntegrationTest(randomPort = true)
 @DirtiesContext
 public abstract class FileSinkTests {
 
@@ -52,7 +51,7 @@ public abstract class FileSinkTests {
 	@Autowired
 	protected Sink sink;
 
-	@WebIntegrationTest({"name = test", "directory = ${java.io.tmpdir}${file.separator}dataflow-tests", "suffix=txt"})
+	@IntegrationTest({"name = test", "directory = ${java.io.tmpdir}${file.separator}dataflow-tests", "suffix=txt"})
 	public static class TextTests extends FileSinkTests {
 
 		@Test
@@ -61,11 +60,12 @@ public abstract class FileSinkTests {
 			File file = new File(ROOT_DIR, "test.txt");
 			file.deleteOnExit();
 			assertTrue("file does not exist", file.exists());
-			assertEquals("this is a test\n", FileCopyUtils.copyToString(new FileReader(file)));
+			assertEquals("this is a test" + System.lineSeparator(), FileCopyUtils.copyToString(new FileReader(file)));
 		}
+
 	}
 
-	@WebIntegrationTest({"binary = true", "directory = ${java.io.tmpdir}${file.separator}dataflow-tests"})
+	@IntegrationTest({"binary = true", "directory = ${java.io.tmpdir}${file.separator}dataflow-tests"})
 	public static class BinaryTests extends FileSinkTests {
 
 		@Test
@@ -78,10 +78,12 @@ public abstract class FileSinkTests {
 			assertEquals(3, results.length);
 			assertArrayEquals("foo".getBytes(), results);
 		}
+
 	}
 
-	@WebIntegrationTest({"nameExpression = payload.substring(0, 4)",
-			"directoryExpression = '${java.io.tmpdir}${file.separator}dataflow-tests${file.separator}'+headers.dir", "suffix=out"})
+	@IntegrationTest({"nameExpression = payload.substring(0, 4)",
+			"directoryExpression = '${java.io.tmpdir}${file.separator}dataflow-tests${file.separator}'+headers.dir",
+			"suffix=out"})
 	public static class ExpressionTests extends FileSinkTests {
 
 		@Test
@@ -91,7 +93,10 @@ public abstract class FileSinkTests {
 			File file = new File(ROOT_DIR + File.separator + "expression", "this.out");
 			file.deleteOnExit();
 			assertTrue("file does not exist", file.exists());
-			assertEquals("this is another test\n", FileCopyUtils.copyToString(new FileReader(file)));
+			assertEquals("this is another test" + System.lineSeparator(),
+					FileCopyUtils.copyToString(new FileReader(file)));
 		}
+
 	}
+
 }

--- a/file-source/src/main/java/org/springframework/cloud/stream/module/file/source/FileSource.java
+++ b/file-source/src/main/java/org/springframework/cloud/stream/module/file/source/FileSource.java
@@ -23,7 +23,6 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.messaging.Source;
-import org.springframework.cloud.stream.module.MaxMessagesProperties;
 import org.springframework.cloud.stream.module.file.FileConsumerProperties;
 import org.springframework.cloud.stream.module.file.FileUtils;
 import org.springframework.cloud.stream.module.trigger.TriggerConfiguration;
@@ -48,8 +47,7 @@ import org.springframework.util.StringUtils;
  */
 @EnableBinding(Source.class)
 @Import(TriggerConfiguration.class)
-@EnableConfigurationProperties({ FileSourceProperties.class,
-	FileConsumerProperties.class, MaxMessagesProperties.class })
+@EnableConfigurationProperties({ FileSourceProperties.class, FileConsumerProperties.class})
 public class FileSource {
 
 	@Autowired

--- a/ftp-sink/pom.xml
+++ b/ftp-sink/pom.xml
@@ -28,7 +28,6 @@
 		<dependency>
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-java-dsl</artifactId>
-			<version>1.1.0.RELEASE</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud.stream.module</groupId>

--- a/ftp-source/src/main/java/org/springframework/cloud/stream/module/ftp/source/FtpSource.java
+++ b/ftp-source/src/main/java/org/springframework/cloud/stream/module/ftp/source/FtpSource.java
@@ -21,7 +21,6 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.cloud.stream.annotation.Bindings;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.messaging.Source;
-import org.springframework.cloud.stream.module.MaxMessagesProperties;
 import org.springframework.cloud.stream.module.file.FileConsumerProperties;
 import org.springframework.cloud.stream.module.file.FileUtils;
 import org.springframework.cloud.stream.module.ftp.FtpSessionFactoryConfiguration;
@@ -47,8 +46,7 @@ import org.springframework.util.StringUtils;
  * @author Gary Russell
  */
 @EnableBinding(Source.class)
-@EnableConfigurationProperties({FtpSourceProperties.class,
-		FileConsumerProperties.class, MaxMessagesProperties.class})
+@EnableConfigurationProperties({FtpSourceProperties.class, FileConsumerProperties.class})
 @Import({TriggerConfiguration.class, FtpSessionFactoryConfiguration.class})
 public class FtpSource {
 

--- a/hdfs-dataset-sink/src/test/java/org/springframework/cloud/stream/module/dataset/sink/DatasetSinkIntegrationTests.java
+++ b/hdfs-dataset-sink/src/test/java/org/springframework/cloud/stream/module/dataset/sink/DatasetSinkIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,11 +18,19 @@ package org.springframework.cloud.stream.module.dataset.sink;
 
 import static org.junit.Assert.assertTrue;
 
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
+import org.junit.Assume;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.SpringApplicationConfiguration;
@@ -37,11 +45,6 @@ import org.springframework.messaging.support.GenericMessage;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-
-import java.io.File;
-import java.io.FilenameFilter;
-import java.io.IOException;
-import java.text.SimpleDateFormat;
 
 /**
  * @author Thomas Risberg
@@ -66,6 +69,11 @@ public abstract class DatasetSinkIntegrationTests {
 	@Autowired
 	@Bindings(DatasetSinkConfiguration.class)
 	protected Sink sink;
+
+	@BeforeClass
+	public static void setupClass() {
+		Assume.assumeFalse(System.getProperty("os.name").startsWith("Windows"));
+	}
 
 	@Before
 	public void setup() throws IOException {

--- a/hdfs-sink/src/test/java/org/springframework/cloud/stream/module/hdfs/sink/HdfsSinkConfigurationTests.java
+++ b/hdfs-sink/src/test/java/org/springframework/cloud/stream/module/hdfs/sink/HdfsSinkConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,19 @@
 
 package org.springframework.cloud.stream.module.hdfs.sink;
 
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+
 import org.junit.After;
-import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.SpringApplicationConfiguration;
@@ -33,72 +41,65 @@ import org.springframework.messaging.support.GenericMessage;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import java.io.File;
-import java.io.FilenameFilter;
-import java.io.IOException;
-import java.nio.charset.Charset;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
 /**
  * @author Thomas Risberg
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = HdfsSinkApplication.class)
 @WebIntegrationTest({"server.port:0",
-        "spring.hadoop.fsUri=file:///",
-        "directory=${java.io.tmpdir}/hdfs-sink",
-        "closeTimeout=100"})
+		"spring.hadoop.fsUri=file:///",
+		"directory=${java.io.tmpdir}/hdfs-sink",
+		"closeTimeout=100"})
 @DirtiesContext
 public class HdfsSinkConfigurationTests {
 
-    @Autowired
-    ConfigurableApplicationContext applicationContext;
+	@Autowired
+	ConfigurableApplicationContext applicationContext;
 
-    @Value("${directory}")
-    private String testDir;
+	@Value("${directory}")
+	private String testDir;
 
-    @Autowired
-    private FsShell fsShell;
+	@Autowired
+	private FsShell fsShell;
 
-    @Autowired
-    @Bindings(HdfsSink.class)
-    private Sink sink;
+	@Autowired
+	@Bindings(HdfsSink.class)
+	private Sink sink;
 
-    @Before
-    public void setup() {
-        if (fsShell.test(testDir)) {
-            fsShell.rmr(testDir);
-        }
-    }
+	@BeforeClass
+	public static void setupClass() {
+		Assume.assumeFalse(System.getProperty("os.name").startsWith("Windows"));
+	}
 
-    @Test
-    public void testWritingSomething() throws IOException, InterruptedException {
-        sink.input().send(new GenericMessage<>("Foo"));
-        Thread.sleep(150);
-        sink.input().send(new GenericMessage<>("Bar"));
-        sink.input().send(new GenericMessage<>("Baz"));
-    }
+	@Before
+	public void setup() {
+		if (fsShell.test(testDir)) {
+			fsShell.rmr(testDir);
+		}
+	}
 
-    @After
-    public void checkFilesClosedOK() throws IOException {
-        applicationContext.close();
-        File testOutput = new File(testDir);
-        assertTrue(testOutput.exists());
-        File[] files = testOutput.listFiles(new FilenameFilter() {
-            @Override
-            public boolean accept(File dir, String name) {
-                if (name.endsWith(".txt")) {
-                    return true;
-                }
-                return false;
-            }
-        });
-        assertTrue(files.length > 1);
-    }
+	@Test
+	public void testWritingSomething() throws IOException, InterruptedException {
+		sink.input().send(new GenericMessage<>("Foo"));
+		Thread.sleep(150);
+		sink.input().send(new GenericMessage<>("Bar"));
+		sink.input().send(new GenericMessage<>("Baz"));
+	}
+
+	@After
+	public void checkFilesClosedOK() throws IOException {
+		applicationContext.close();
+		File testOutput = new File(testDir);
+		assertTrue(testOutput.exists());
+		File[] files = testOutput.listFiles(new FilenameFilter() {
+
+			@Override
+			public boolean accept(File dir, String name) {
+				return name.endsWith(".txt");
+			}
+
+		});
+		assertTrue(files.length > 1);
+	}
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
 			<dependency>
 				<groupId>org.springframework.integration</groupId>
 				<artifactId>spring-integration-java-dsl</artifactId>
-				<version>1.1.0.RELEASE</version>
+				<version>1.1.2.RELEASE</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.ftpserver</groupId>

--- a/sftp-source/src/main/java/org/springframework/cloud/stream/module/sftp/source/SftpSource.java
+++ b/sftp-source/src/main/java/org/springframework/cloud/stream/module/sftp/source/SftpSource.java
@@ -20,7 +20,6 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.messaging.Source;
-import org.springframework.cloud.stream.module.MaxMessagesProperties;
 import org.springframework.cloud.stream.module.file.FileConsumerProperties;
 import org.springframework.cloud.stream.module.file.FileUtils;
 import org.springframework.cloud.stream.module.sftp.SftpSessionFactoryConfiguration;
@@ -44,8 +43,7 @@ import org.springframework.util.StringUtils;
  * @author Gary Russell
  */
 @EnableBinding(Source.class)
-@EnableConfigurationProperties({SftpSourceProperties.class,
-		FileConsumerProperties.class, MaxMessagesProperties.class})
+@EnableConfigurationProperties({SftpSourceProperties.class, FileConsumerProperties.class})
 @Import({TriggerConfiguration.class, SftpSessionFactoryConfiguration.class})
 public class SftpSource {
 

--- a/trigger-source/src/main/java/org/springframework/cloud/stream/module/trigger/TriggerSource.java
+++ b/trigger-source/src/main/java/org/springframework/cloud/stream/module/trigger/TriggerSource.java
@@ -12,13 +12,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.cloud.stream.module.trigger;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.messaging.Source;
-import org.springframework.cloud.stream.module.MaxMessagesProperties;
+import org.springframework.cloud.stream.module.SourcePayloadProperties;
 import org.springframework.cloud.stream.module.annotation.PollableSource;
 import org.springframework.context.annotation.Import;
 
@@ -26,18 +27,19 @@ import org.springframework.context.annotation.Import;
  * Trigger source module.
  *
  * @author Ilayaperumal Gopinathan
+ * @author Artem Bilan
  */
 @EnableBinding(Source.class)
-@EnableConfigurationProperties({TriggerProperties.class, MaxMessagesProperties.class})
+@EnableConfigurationProperties(SourcePayloadProperties.class)
 @Import(TriggerConfiguration.class)
 public class TriggerSource {
 
 	@Autowired
-	private TriggerProperties config;
+	private SourcePayloadProperties payloadProperties;
 
 	@PollableSource
 	public Object triggerSource() {
-		return this.config.getPayload().getValue();
+		return this.payloadProperties.getPayload().getValue();
 	}
 
 }

--- a/websocket-sink/pom.xml
+++ b/websocket-sink/pom.xml
@@ -21,10 +21,6 @@
 			<groupId>org.springframework.cloud.stream.module</groupId>
 			<artifactId>spring-cloud-stream-modules-common-configuration</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-java-dsl</artifactId>
-		</dependency>
 
 		<!-- 3rd PARTY DEPENDENCIES -->
 		<dependency>


### PR DESCRIPTION
- Upgrade to SI Java DSL 1.1.2
- Introduce `SourcePayloadProperties` to move `payload` option outside of any `Source` module.
  Right now it makes sense only for the `TriggerSource`.
- Make some tests ignorable on Windows, since they are not intended to pass there.
- Add `server.port=-1` for the `CassandraSinkIntegrationTests` to make it a bit faster bypassing Tomcat start.
- Close context in the `CassandraSinkPropertiesTests`.
- Remove redundant usage of `MaxMessagesProperties` in the Source modules since it is picked up by the `TriggerConfiguration`.
