### PR TITLE
Better address discovery for gpfdist

### DIFF
--- a/gpfdist-sink/pom.xml
+++ b/gpfdist-sink/pom.xml
@@ -19,6 +19,7 @@
 		<codahale.version>3.0.2</codahale.version>
 		<netty.version>4.0.27.Final</netty.version>
 		<postgresql.version>9.4-1201-jdbc41</postgresql.version>
+		<commonsnet.version>3.1</commonsnet.version>
 		<skipITs>true</skipITs>
 	</properties>
 
@@ -45,6 +46,11 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-jdbc</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>commons-net</groupId>
+			<artifactId>commons-net</artifactId>
+			<version>${commonsnet.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>io.netty</groupId>

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/GpfdistMessageHandler.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/GpfdistMessageHandler.java
@@ -23,6 +23,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.reactivestreams.Processor;
+import org.springframework.cloud.stream.module.gpfdist.sink.net.HostInfoDiscovery;
 import org.springframework.cloud.stream.module.gpfdist.sink.support.GreenplumLoad;
 import org.springframework.cloud.stream.module.gpfdist.sink.support.NetworkUtils;
 import org.springframework.cloud.stream.module.gpfdist.sink.support.RuntimeContext;
@@ -62,6 +63,7 @@ public class GpfdistMessageHandler extends AbstractGpfdistMessageHandler {
 	private int rateInterval = 0;
 	private Meter meter =  null;
 	private int meterCount = 0;
+	private final HostInfoDiscovery hostInfoDiscovery;
 
 	/**
 	 * Instantiates a new gpfdist message handler.
@@ -73,9 +75,10 @@ public class GpfdistMessageHandler extends AbstractGpfdistMessageHandler {
 	 * @param batchCount the batch count
 	 * @param batchPeriod the batch period
 	 * @param delimiter the delimiter
+	 * @param hostInfoDiscovery the host info discovery
 	 */
 	public GpfdistMessageHandler(int port, int flushCount, int flushTime, int batchTimeout, int batchCount,
-			int batchPeriod, String delimiter) {
+			int batchPeriod, String delimiter, HostInfoDiscovery hostInfoDiscovery) {
 		super();
 		this.port = port;
 		this.flushCount = flushCount;
@@ -84,6 +87,7 @@ public class GpfdistMessageHandler extends AbstractGpfdistMessageHandler {
 		this.batchCount = batchCount;
 		this.batchPeriod = batchPeriod;
 		this.delimiter = StringUtils.hasLength(delimiter) ? delimiter : null;
+		this.hostInfoDiscovery = hostInfoDiscovery;
 	}
 
 	@Override
@@ -129,7 +133,7 @@ public class GpfdistMessageHandler extends AbstractGpfdistMessageHandler {
 			log.info("Scheduling gpload task with batchPeriod=" + batchPeriod);
 
 			final RuntimeContext context = new RuntimeContext();
-			context.addLocation(NetworkUtils.getGPFDistUri(gpfdistServer.getLocalPort()));
+			context.addLocation(NetworkUtils.getGPFDistUri(hostInfoDiscovery.getHostInfo().getAddress(), gpfdistServer.getLocalPort()));
 
 			sqlTaskScheduler.schedule((new FutureTask<Void>(new Runnable() {
 				@Override

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/net/DefaultHostInfoDiscovery.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/net/DefaultHostInfoDiscovery.java
@@ -1,0 +1,301 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.stream.module.gpfdist.sink.net;
+
+import java.net.InetAddress;
+import java.net.InterfaceAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Enumeration;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.commons.net.util.SubnetUtils;
+import org.apache.commons.net.util.SubnetUtils.SubnetInfo;
+import org.springframework.util.StringUtils;
+
+/**
+ * Default implementation of {@link HostInfoDiscovery}.
+ * <p>
+ * Discovery logic for finding ip address is:
+ * <p>
+ * <ul>
+ * <li>all possible network interfaces are requested
+ * <li>for interfaces, filter out point to point if not enabled
+ * <li>for interfaces, filter out loopback if not enabled
+ * <li>for interfaces, explicit regex patter match is done if pattern is set
+ * <li>interfaces are sort by preferred name prefixes, on default "eth" and "en" are sort first
+ * <li>interfaces are sorted by their indexes assuming eth0 should be picked over eth1
+ * <li>interfaces are checked by their list of ip addresses
+ * <li>only ipv4 ip's are taken
+ * <li>cidr notation to match if from a network/mask is taken in defined
+ * <li>what is left, first found ip is taken
+ * </ul>
+ * <p>
+ * Typical config(with all options used) might look like:
+ * <pre>
+ * spring:
+ *   net:
+ *     hostdiscovery:
+ *       pointToPoint: false
+ *       loopback: false
+ *       preferInterface: ['eth', 'en']
+ *       matchIpv4: 192.168.0.0/24
+ *       matchInterface: eth\\d*
+ * </pre>
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class DefaultHostInfoDiscovery implements HostInfoDiscovery {
+
+	private final Log log = LogFactory.getLog(DefaultHostInfoDiscovery.class);
+	private String matchIpv4;
+	private String matchInterface;
+	private List<String> preferInterface = Arrays.asList("eth", "en");
+	private boolean pointToPoint = false;
+	private boolean loopback = false;
+
+	@Override
+	public HostInfo getHostInfo() {
+		List<NetworkInterface> interfaces;
+		try {
+			interfaces = getAllAvailableInterfaces();
+		} catch (SocketException e) {
+			return null;
+		}
+
+		if (log.isDebugEnabled()) {
+			log.debug("Interfaces before filter: " + interfaces);
+		}
+		// pre filter candidates
+		interfaces = filterInterfaces(interfaces);
+		if (log.isDebugEnabled()) {
+			log.debug("Interfaces after filter: " + interfaces);
+		}
+
+		// sort to prepare getting first match
+		interfaces = sortInterfaces(interfaces);
+		if (log.isDebugEnabled()) {
+			log.debug("Interfaces after sort: " + interfaces);
+		}
+
+		for (NetworkInterface nic : interfaces) {
+			List<InetAddress> addresses = new ArrayList<InetAddress>();
+			for (InterfaceAddress interfaceAddress : nic.getInterfaceAddresses()) {
+				addresses.add(interfaceAddress.getAddress());
+			}
+			if (log.isDebugEnabled()) {
+				log.debug("Addresses before filter: " + interfaces);
+			}
+			addresses = filterAddresses(addresses);
+			log.info("Discovered addresses(returning first): " + addresses);
+			if (!addresses.isEmpty()) {
+				InetAddress address = addresses.get(0);
+				return new HostInfo(address.getHostAddress(), address.getHostName());
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Sets the match ipv4. Used to match ip address from
+	 * a network using a cidr notation. For example, "192.168.0.1/24"
+	 * matches range "192.168.0.1-192.168.0.254", "192.168.0.1/16"
+	 * matches ranre "192.168.0.1-192.168.255.254" and
+	 * "10.0.0.1/8" matches range "10.0.0.1-10.255.255.254"
+	 *
+	 * @param matchIpv4 the new match ipv4
+	 */
+	public void setMatchIpv4(String matchIpv4) {
+		this.matchIpv4 = matchIpv4;
+	}
+
+	/**
+	 * Use interface as a candidate if its name is matching with a
+	 * given pattern. Default value is is empty.
+	 *
+	 * @param matchInterface the new match interface regex patter
+	 * @see NetworkInterface#getName()
+	 */
+	public void setMatchInterface(String matchInterface) {
+		this.matchInterface = matchInterface;
+	}
+
+	/**
+	 * Sets the preferred interfaces. Sort interfaces in such
+	 * order that interface names prefixed with values found from
+	 * a list is considered first candidates. Defaults to "eth" and
+	 * "en" which usually are the ones found from unix systems.
+	 *
+	 * @param preferInterface the new preferred interface list
+	 */
+	public void setPreferInterface(List<String> preferInterface) {
+		this.preferInterface = preferInterface;
+	}
+
+	/**
+	 * Sets if interfaces marked as point to point should be handled.
+	 * Point to point nic is usually a vpn tunnel which may not be no
+	 * use to talk to a host unless communication goes through vpn.
+	 * Default value is <code>FALSE</code>.
+	 *
+	 * @param pointToPoint the new point to point flag
+	 * @see NetworkInterface#isPointToPoint()
+	 */
+	public void setPointToPoint(boolean pointToPoint) {
+		this.pointToPoint = pointToPoint;
+	}
+
+	/**
+	 * Sets if loopback should be discovered.
+	 * Default value is <code>FALSE</code>.
+	 *
+	 * @param loopback the new loopback flag
+	 */
+	public void setLoopback(boolean loopback) {
+		this.loopback = loopback;
+	}
+
+	protected List<NetworkInterface> getAllAvailableInterfaces() throws SocketException {
+		List<NetworkInterface> interfaces = new ArrayList<NetworkInterface>(5);
+		for (Enumeration<NetworkInterface> e = NetworkInterface.getNetworkInterfaces(); e.hasMoreElements();) {
+			interfaces.add(e.nextElement());
+		}
+		return interfaces;
+	}
+
+	private List<InetAddress> filterAddresses(List<InetAddress> addresses) {
+		List<InetAddress> filtered = new ArrayList<InetAddress>();
+		for (InetAddress address : addresses) {
+			// take only ipv4 addresses whose byte array length is always 4
+			boolean match = address.getAddress() != null && address.getAddress().length == 4;
+
+			// check loopback
+			if (!loopback && address.isLoopbackAddress()) {
+				match = false;
+			}
+
+			// match cidr if defined
+			if (match && StringUtils.hasText(matchIpv4)) {
+				match = matchIpv4(matchIpv4, address.getHostAddress());
+			}
+
+			if (match) {
+				filtered.add(address);
+			}
+		}
+		return filtered;
+	}
+
+	private boolean matchIpv4(String addressMatch, String address) {
+		// TODO: should we fork utils from jakarta commons?
+		SubnetUtils subnetUtils = new SubnetUtils(addressMatch);
+		SubnetInfo info = subnetUtils.getInfo();
+		return info.isInRange(address);
+	}
+
+	private List<NetworkInterface> filterInterfaces(List<NetworkInterface> interfaces) {
+		List<NetworkInterface> filtered = new ArrayList<NetworkInterface>();
+		for (NetworkInterface nic : interfaces) {
+			boolean match = false;
+
+			try {
+				match = pointToPoint && nic.isPointToPoint();
+			} catch (SocketException e) {
+			}
+
+			try {
+				match = !match && loopback && nic.isLoopback();
+			} catch (SocketException e) {
+			}
+
+			// last, if we didn't match anything, let all pass
+			// if matchInterface is not set, otherwise do pattern
+			// matching
+			if (!match && !StringUtils.hasText(matchInterface)) {
+				match = true;
+			} else if (StringUtils.hasText(matchInterface)) {
+				match = nic.getName().matches(matchInterface);
+			}
+
+			if (match) {
+				filtered.add(nic);
+			}
+		}
+		return filtered;
+	}
+
+	private List<NetworkInterface> sortInterfaces(List<NetworkInterface> interfaces) {
+		Collections.sort(interfaces, new NicIndexComparator());
+		Collections.sort(interfaces, new NicPreferNameComparator());
+		return interfaces;
+	}
+
+	/**
+	 * Comparator to sort with nic index.
+	 */
+	private class NicIndexComparator implements Comparator<NetworkInterface> {
+
+		@Override
+		public int compare(NetworkInterface o1, NetworkInterface o2) {
+			return Integer.compare(o1.getIndex(), o2.getIndex());
+		}
+	}
+
+	/**
+	 * Comparator for nic names preferring a list of give prefixes order
+	 * to sort those before any other.
+	 */
+	private class NicPreferNameComparator implements Comparator<NetworkInterface> {
+
+		@Override
+		public int compare(NetworkInterface o1, NetworkInterface o2) {
+			String o1name = o1.getName();
+			String o2name = o2.getName();
+			if (startWithAny(preferInterface, o1name) && startWithAny(preferInterface, o2name)) {
+				return 0;
+			} else if (startWithAny(preferInterface, o1name) && !startWithAny(preferInterface, o2name)) {
+				return -1;
+			} else if (!startWithAny(preferInterface, o1name) && startWithAny(preferInterface, o2name)) {
+				return 1;
+			} else {
+				return o1name.compareTo(o2name);
+			}
+		}
+
+		private boolean startWithAny(List<String> prefixes, String name) {
+			for (String prefix : prefixes) {
+				if (name.startsWith(prefix)) {
+					return true;
+				}
+			}
+			return false;
+		}
+	}
+
+	@Override
+	public String toString() {
+		return "DefaultHostInfoDiscovery [matchIpv4=" + matchIpv4 + ", matchInterface=" + matchInterface + ", preferInterface="
+				+ preferInterface + ", pointToPoint=" + pointToPoint + ", loopback=" + loopback + "]";
+	}
+
+}

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/net/HostInfoDiscovery.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/net/HostInfoDiscovery.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.stream.module.gpfdist.sink.net;
+
+/**
+ * Interface used to discover a {@link HostInfo} from a system.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public interface HostInfoDiscovery {
+
+	/**
+	 * Gets the host info.
+	 *
+	 * @return the host info
+	 */
+	HostInfo getHostInfo();
+
+	/**
+	 * Class wrapping host information.
+	 */
+	public static final class HostInfo {
+		private final String address;
+		private final String hostname;
+
+		/**
+		 * Instantiates a new host info.
+		 *
+		 * @param address the address
+		 * @param hostname the hostname
+		 */
+		public HostInfo(String address, String hostname) {
+			super();
+			this.address = address;
+			this.hostname = hostname;
+		}
+
+		/**
+		 * Gets the ip address as represented in string.
+		 *
+		 * @return the ip address
+		 */
+		public String getAddress() {
+			return address;
+		}
+
+		/**
+		 * Gets the hostname.
+		 *
+		 * @return the hostname
+		 */
+		public String getHostname() {
+			return hostname;
+		}
+	}
+
+}

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/net/HostInfoDiscoveryProperties.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/net/HostInfoDiscoveryProperties.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.stream.module.gpfdist.sink.net;
+
+import java.util.List;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Shared boot configuration properties for "spring.net.hostdiscovery".
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@ConfigurationProperties(value = "spring.net.hostdiscovery")
+public class HostInfoDiscoveryProperties {
+
+	private String matchIpv4;
+	private String matchInterface;
+	private List<String> preferInterface;
+	private boolean pointToPoint = false;
+	private boolean loopback = false;
+
+	public String getMatchIpv4() {
+		return matchIpv4;
+	}
+
+	public void setMatchIpv4(String matchIpv4) {
+		this.matchIpv4 = matchIpv4;
+	}
+
+	public String getMatchInterface() {
+		return matchInterface;
+	}
+
+	public void setMatchInterface(String matchInterface) {
+		this.matchInterface = matchInterface;
+	}
+
+	public List<String> getPreferInterface() {
+		return preferInterface;
+	}
+
+	public void setPreferInterface(List<String> preferInterface) {
+		this.preferInterface = preferInterface;
+	}
+
+	public boolean isPointToPoint() {
+		return pointToPoint;
+	}
+
+	public void setPointToPoint(boolean pointToPoint) {
+		this.pointToPoint = pointToPoint;
+	}
+
+	public boolean isLoopback() {
+		return loopback;
+	}
+
+	public void setLoopback(boolean loopback) {
+		this.loopback = loopback;
+	}
+
+}

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/NetworkUtils.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/NetworkUtils.java
@@ -15,12 +15,6 @@
  */
 package org.springframework.cloud.stream.module.gpfdist.sink.support;
 
-import java.net.Inet6Address;
-import java.net.InetAddress;
-import java.net.NetworkInterface;
-import java.net.SocketException;
-import java.util.Enumeration;
-
 /**
  * Various network utilities.
  *
@@ -30,35 +24,14 @@ import java.util.Enumeration;
 public class NetworkUtils {
 
 	/**
-	 * Gets the main network address.
+	 * Gets the GPF dist uri by address and port.
 	 *
-	 * @return network address, null if not found
+	 * @param address the address
+	 * @param port the port
+	 * @return the GPF dist uri
 	 */
-	public static String getDefaultAddress() {
-		Enumeration<NetworkInterface> nets;
-		try {
-			nets = NetworkInterface.getNetworkInterfaces();
-		} catch (SocketException e) {
-			return null;
-		}
-		NetworkInterface netinf;
-		while (nets.hasMoreElements()) {
-			netinf = nets.nextElement();
-
-			Enumeration<InetAddress> addresses = netinf.getInetAddresses();
-
-			while (addresses.hasMoreElements()) {
-				InetAddress address = addresses.nextElement();
-				if (!address.isAnyLocalAddress() && !address.isMulticastAddress() && !(address instanceof Inet6Address)) {
-					return address.getHostAddress();
-				}
-			}
-		}
-		return null;
-	}
-
-	public static String getGPFDistUri(int port) {
-		return "gpfdist://" + getDefaultAddress() + ":" + port + "/data";
+	public static String getGPFDistUri(String address, int port) {
+		return "gpfdist://" + address + ":" + port + "/data";
 	}
 
 }

--- a/gpfdist-sink/src/test/java/org/springframework/cloud/stream/module/gpfdist/sink/AbstractLoadTests.java
+++ b/gpfdist-sink/src/test/java/org/springframework/cloud/stream/module/gpfdist/sink/AbstractLoadTests.java
@@ -23,6 +23,7 @@ import org.apache.commons.dbcp.BasicDataSource;
 import org.junit.After;
 import org.junit.Before;
 import org.reactivestreams.Processor;
+import org.springframework.cloud.stream.module.gpfdist.sink.net.DefaultHostInfoDiscovery;
 import org.springframework.cloud.stream.module.gpfdist.sink.support.Format;
 import org.springframework.cloud.stream.module.gpfdist.sink.support.LoadConfiguration;
 import org.springframework.cloud.stream.module.gpfdist.sink.support.LoadFactoryBean;
@@ -63,7 +64,8 @@ public abstract class AbstractLoadTests {
 		@Bean
 		public ReadableTableFactoryBean greenplumReadableTable() {
 			ReadableTableFactoryBean factory = new ReadableTableFactoryBean();
-			factory.setLocations(Arrays.asList(NetworkUtils.getGPFDistUri(8080)));
+			DefaultHostInfoDiscovery discovery = new DefaultHostInfoDiscovery();
+			factory.setLocations(Arrays.asList(NetworkUtils.getGPFDistUri(discovery.getHostInfo().getAddress(), 8080)));
 			factory.setFormat(Format.TEXT);
 			return factory;
 		}

--- a/gpfdist-sink/src/test/java/org/springframework/cloud/stream/module/gpfdist/sink/net/HostInfoDiscoveryPropertiesTests.java
+++ b/gpfdist-sink/src/test/java/org/springframework/cloud/stream/module/gpfdist/sink/net/HostInfoDiscoveryPropertiesTests.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.stream.module.gpfdist.sink.net;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Configuration;
+
+public class HostInfoDiscoveryPropertiesTests {
+
+	@Test
+	public void testAllSet() {
+		SpringApplication app = new SpringApplication(TestConfiguration.class);
+		app.setWebEnvironment(false);
+		ConfigurableApplicationContext context = app
+				.run(new String[] { "--spring.net.hostdiscovery.pointToPoint=true",
+						"--spring.net.hostdiscovery.loopback=true",
+						"--spring.net.hostdiscovery.preferInterface=lxcbr",
+						"--spring.net.hostdiscovery.matchIpv4=192.168.0.0/24",
+						"--spring.net.hostdiscovery.matchInterface=eth0" });
+
+		HostInfoDiscoveryProperties properties = context.getBean(HostInfoDiscoveryProperties.class);
+		assertThat(properties, notNullValue());
+		assertThat(properties.isPointToPoint(), is(true));
+		assertThat(properties.isLoopback(), is(true));
+		assertThat(properties.getPreferInterface(), notNullValue());
+		assertThat(properties.getPreferInterface().size(), is(1));
+		assertThat(properties.getMatchIpv4(), is("192.168.0.0/24"));
+		assertThat(properties.getMatchInterface(), is("eth0"));
+		context.close();
+	}
+
+	@Test
+	public void testPreferOne() {
+		SpringApplication app = new SpringApplication(TestConfiguration.class);
+		app.setWebEnvironment(false);
+		ConfigurableApplicationContext context = app
+				.run(new String[] { "--spring.net.hostdiscovery.preferInterface=lxcbr" });
+
+		HostInfoDiscoveryProperties properties = context.getBean(HostInfoDiscoveryProperties.class);
+		assertThat(properties, notNullValue());
+		assertThat(properties.getPreferInterface(), notNullValue());
+		assertThat(properties.getPreferInterface().size(), is(1));
+		context.close();
+	}
+
+	@Test
+	public void testPreferTwo() {
+		SpringApplication app = new SpringApplication(TestConfiguration.class);
+		app.setWebEnvironment(false);
+		ConfigurableApplicationContext context = app
+				.run(new String[] { "--spring.net.hostdiscovery.preferInterface=lxcbr,foo" });
+
+		HostInfoDiscoveryProperties properties = context.getBean(HostInfoDiscoveryProperties.class);
+		assertThat(properties, notNullValue());
+		assertThat(properties.getPreferInterface(), notNullValue());
+		assertThat(properties.getPreferInterface().size(), is(2));
+		assertThat(properties.getPreferInterface(), containsInAnyOrder("lxcbr", "foo"));
+		context.close();
+	}
+
+	@Configuration
+	@EnableConfigurationProperties({ HostInfoDiscoveryProperties.class })
+	protected static class TestConfiguration {
+	}
+
+}


### PR DESCRIPTION
- Basically copying over discovery logic
  made for spring yarn order to be
  as flexible as possible.
- Under `spring.net.hostdiscovery` we can use
  options `pointToPoint`, `loopback`, `preferInterface`,
  `matchIpv4` and `matchInterface` to set logic how correct
  address is discovered.
- Fixes #160

To test(assuming gpdb running on `mdw`)

and table created:

```
gpadmin=# create table ticktock (date text, time text);
```

```
java -jar time-source/target/time-source-1.0.0.BUILD-SNAPSHOT-exec.jar --server.port=8081 --spring.cloud.stream.bindings.output=xxx
java -jar gpfdist-sink/target/gpfdist-sink-1.0.0.BUILD-SNAPSHOT-exec.jar --server.port=8082 --spring.cloud.stream.bindings.input=xxx --dbHost=mdw --table=ticktock --batchTime=1 --batchPeriod=1 --flushCount=2 --flushTime=2 --columnDelimiter=" " --spring.net.hostdiscovery.matchInterface=eth0
```

and play with options.

There's a short moment when external table exists:

```
gpadmin=# \d ticktock_ext_71e73035_656c_40bf_9ebd_6447166b8e58
External table "public.ticktock_ext_71e73035_656c_40bf_9ebd_6447166b8e58"
 Column | Type | Modifiers 
--------+------+-----------
 date   | text | 
 time   | text | 
Type: readable
Encoding: UTF8
Format type: text
Format options: delimiter ' ' null '\N' escape '\'
External location: gpfdist://10.0.3.1:44742/data
```
