### PR TITLE
[DO NOT MERGE] Add dataflow.properties file to modules

### DIFF
--- a/cassandra-sink/src/main/resources/META-INF/dataflow.properties
+++ b/cassandra-sink/src/main/resources/META-INF/dataflow.properties
@@ -1,0 +1,1 @@
+configuration.classes=org.springframework.cloud.stream.module.cassandra.CassandraProperties


### PR DESCRIPTION
This is a placeholder PR for when https://github.com/spring-cloud/spring-cloud-dataflow/pull/432 is in.

At the moment, only the `cassandra-sink` module is concerned, to ease review of the aforementioned PR.
