### PR TITLE
GH-216: Rabbit Source - Don't Map DeliveryMode

### DIFF
--- a/rabbit-source/src/main/java/org/springframework/cloud/stream/module/rabbit/source/RabbitSourceProperties.java
+++ b/rabbit-source/src/main/java/org/springframework/cloud/stream/module/rabbit/source/RabbitSourceProperties.java
@@ -47,7 +47,7 @@ public class RabbitSourceProperties {
 	/**
 	 * Headers that will be mapped.
 	 */
-	private String[] mappedRequestHeaders = { "*" };
+	private String[] mappedRequestHeaders = { "STANDARD_REQUEST_HEADERS" };
 
 	/**
 	 * Initial retry interval when retry is enabled.

--- a/rabbit-source/src/test/java/org/springframework/cloud/stream/module/rabbit/source/RabbitSourceTests.java
+++ b/rabbit-source/src/test/java/org/springframework/cloud/stream/module/rabbit/source/RabbitSourceTests.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.stream.module.rabbit.source;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.concurrent.TimeUnit;
@@ -34,6 +35,7 @@ import org.springframework.amqp.core.MessagePostProcessor;
 import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
+import org.springframework.amqp.support.AmqpHeaders;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.IntegrationTest;
 import org.springframework.boot.test.SpringApplicationConfiguration;
@@ -117,6 +119,7 @@ public abstract class RabbitSourceTests {
 			assertNotNull(out);
 			assertEquals("foo", out.getPayload());
 			assertEquals("baz", out.getHeaders().get("bar"));
+			assertNull(out.getHeaders().get(AmqpHeaders.DELIVERY_MODE));
 		}
 
 	}

--- a/spring-cloud-stream-modules-docs/src/main/asciidoc/sources.adoc
+++ b/spring-cloud-stream-modules-docs/src/main/asciidoc/sources.adoc
@@ -145,7 +145,7 @@ The **$$rabbit$$** $$source$$ has the following options:
 
 $$enableRetry$$:: $$enable retry; when retries are exhausted the message will be rejected; message disposition will depend on dead letter configuration$$ *($$boolean$$, default: `false`)*
 $$initialRetryInterval$$:: $$initial interval between retries$$ *($$int$$, default: `1000`)*
-$$mappedRequestHeaders$$:: $$request message header names to be mapped from the incoming message; to limit to the set of standard headers plus `bar`, use `STANDARD_REQUEST_HEADERS,bar`$$ *($$String$$, default: `*`)*
+$$mappedRequestHeaders$$:: $$request message header names to be mapped from the incoming message$$ *($$String$$, default: `STANDARD_REQUEST_HEADERS`)*
 $$maxAttempts$$:: $$maximum delivery attempts$$ *($$int$$, default: `3`)*
 $$maxConcurrency$$:: $$the maximum number of consumers$$ *($$int$$, default: `1`)*
 $$maxRetryInterval$$:: $$maximum retry interval$$ *($$int$$, default: `30000`)*


### PR DESCRIPTION
Resolves #216

Suppress the delivery mode header to avoid inadvertent propagation when
using the rabbit binder.

Also revert the default inbound mapping to only `STANDARD_REQUEST_HEADERS` since
unexpected results may occur when mapping all headers.

See the CAUTION here: http://docs.spring.io/spring-integration/reference/html/amqp.html#amqp-message-headers
