### PR TITLE
Use redis as the default store for analytics

### DIFF
--- a/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/metrics/MetricProperties.java
+++ b/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/metrics/MetricProperties.java
@@ -29,7 +29,7 @@ public class MetricProperties {
 	 * The name of a store used to store the counter.
 	 */
 	// Stored as a String to allow forward extension of the module
-	private String store = "memory";
+	private String store = "redis";
 
 	public String getStore() {
 		return store;


### PR DESCRIPTION
Fixes spring-cloud/spring-cloud-stream-modules#214

No tests were harmed during the making of this PR.
