### PR TITLE
Better address discovery for gpfdist

### DIFF
--- a/gpfdist-sink/pom.xml
+++ b/gpfdist-sink/pom.xml
@@ -19,6 +19,7 @@
 		<codahale.version>3.0.2</codahale.version>
 		<netty.version>4.0.27.Final</netty.version>
 		<postgresql.version>9.4-1201-jdbc41</postgresql.version>
+		<spring-data-hadoop.version>2.4.0.M1</spring-data-hadoop.version>
 		<skipITs>true</skipITs>
 	</properties>
 
@@ -57,6 +58,18 @@
 			<artifactId>postgresql</artifactId>
 			<version>${postgresql.version}</version>
 			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-hadoop-util</artifactId>
+			<version>${spring-data-hadoop.version}</version>
+			<scope>provided</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.hadoop</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 	</dependencies>
 

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/GpfdistMessageHandler.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/GpfdistMessageHandler.java
@@ -26,6 +26,7 @@ import org.reactivestreams.Processor;
 import org.springframework.cloud.stream.module.gpfdist.sink.support.GreenplumLoad;
 import org.springframework.cloud.stream.module.gpfdist.sink.support.NetworkUtils;
 import org.springframework.cloud.stream.module.gpfdist.sink.support.RuntimeContext;
+import org.springframework.data.hadoop.util.net.HostInfoDiscovery;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandlingException;
 import org.springframework.scheduling.TaskScheduler;
@@ -62,6 +63,7 @@ public class GpfdistMessageHandler extends AbstractGpfdistMessageHandler {
 	private int rateInterval = 0;
 	private Meter meter =  null;
 	private int meterCount = 0;
+	private final HostInfoDiscovery hostInfoDiscovery;
 
 	/**
 	 * Instantiates a new gpfdist message handler.
@@ -73,9 +75,10 @@ public class GpfdistMessageHandler extends AbstractGpfdistMessageHandler {
 	 * @param batchCount the batch count
 	 * @param batchPeriod the batch period
 	 * @param delimiter the delimiter
+	 * @param hostInfoDiscovery the host info discovery
 	 */
 	public GpfdistMessageHandler(int port, int flushCount, int flushTime, int batchTimeout, int batchCount,
-			int batchPeriod, String delimiter) {
+			int batchPeriod, String delimiter, HostInfoDiscovery hostInfoDiscovery) {
 		super();
 		this.port = port;
 		this.flushCount = flushCount;
@@ -84,6 +87,7 @@ public class GpfdistMessageHandler extends AbstractGpfdistMessageHandler {
 		this.batchCount = batchCount;
 		this.batchPeriod = batchPeriod;
 		this.delimiter = StringUtils.hasLength(delimiter) ? delimiter : null;
+		this.hostInfoDiscovery = hostInfoDiscovery;
 	}
 
 	@Override
@@ -129,7 +133,7 @@ public class GpfdistMessageHandler extends AbstractGpfdistMessageHandler {
 			log.info("Scheduling gpload task with batchPeriod=" + batchPeriod);
 
 			final RuntimeContext context = new RuntimeContext();
-			context.addLocation(NetworkUtils.getGPFDistUri(gpfdistServer.getLocalPort()));
+			context.addLocation(NetworkUtils.getGPFDistUri(hostInfoDiscovery.getHostInfo().getAddress(), gpfdistServer.getLocalPort()));
 
 			sqlTaskScheduler.schedule((new FutureTask<Void>(new Runnable() {
 				@Override

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/HostInfoDiscoveryProperties.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/HostInfoDiscoveryProperties.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.stream.module.gpfdist.sink;
+
+import java.util.List;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Shared boot configuration properties for "spring.net.hostdiscovery".
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@ConfigurationProperties(value = "spring.net.hostdiscovery")
+public class HostInfoDiscoveryProperties {
+
+	private String matchIpv4;
+	private String matchInterface;
+	private List<String> preferInterface;
+	private boolean pointToPoint = false;
+	private boolean loopback = false;
+
+	public String getMatchIpv4() {
+		return matchIpv4;
+	}
+
+	public void setMatchIpv4(String matchIpv4) {
+		this.matchIpv4 = matchIpv4;
+	}
+
+	public String getMatchInterface() {
+		return matchInterface;
+	}
+
+	public void setMatchInterface(String matchInterface) {
+		this.matchInterface = matchInterface;
+	}
+
+	public List<String> getPreferInterface() {
+		return preferInterface;
+	}
+
+	public void setPreferInterface(List<String> preferInterface) {
+		this.preferInterface = preferInterface;
+	}
+
+	public boolean isPointToPoint() {
+		return pointToPoint;
+	}
+
+	public void setPointToPoint(boolean pointToPoint) {
+		this.pointToPoint = pointToPoint;
+	}
+
+	public boolean isLoopback() {
+		return loopback;
+	}
+
+	public void setLoopback(boolean loopback) {
+		this.loopback = loopback;
+	}
+}

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/NetworkUtils.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/NetworkUtils.java
@@ -15,12 +15,6 @@
  */
 package org.springframework.cloud.stream.module.gpfdist.sink.support;
 
-import java.net.Inet6Address;
-import java.net.InetAddress;
-import java.net.NetworkInterface;
-import java.net.SocketException;
-import java.util.Enumeration;
-
 /**
  * Various network utilities.
  *
@@ -29,36 +23,7 @@ import java.util.Enumeration;
  */
 public class NetworkUtils {
 
-	/**
-	 * Gets the main network address.
-	 *
-	 * @return network address, null if not found
-	 */
-	public static String getDefaultAddress() {
-		Enumeration<NetworkInterface> nets;
-		try {
-			nets = NetworkInterface.getNetworkInterfaces();
-		} catch (SocketException e) {
-			return null;
-		}
-		NetworkInterface netinf;
-		while (nets.hasMoreElements()) {
-			netinf = nets.nextElement();
-
-			Enumeration<InetAddress> addresses = netinf.getInetAddresses();
-
-			while (addresses.hasMoreElements()) {
-				InetAddress address = addresses.nextElement();
-				if (!address.isAnyLocalAddress() && !address.isMulticastAddress() && !(address instanceof Inet6Address)) {
-					return address.getHostAddress();
-				}
-			}
-		}
-		return null;
+	public static String getGPFDistUri(String address, int port) {
+		return "gpfdist://" + address + ":" + port + "/data";
 	}
-
-	public static String getGPFDistUri(int port) {
-		return "gpfdist://" + getDefaultAddress() + ":" + port + "/data";
-	}
-
 }

--- a/gpfdist-sink/src/test/java/org/springframework/cloud/stream/module/gpfdist/sink/AbstractLoadTests.java
+++ b/gpfdist-sink/src/test/java/org/springframework/cloud/stream/module/gpfdist/sink/AbstractLoadTests.java
@@ -30,6 +30,7 @@ import org.springframework.cloud.stream.module.gpfdist.sink.support.NetworkUtils
 import org.springframework.cloud.stream.module.gpfdist.sink.support.ReadableTableFactoryBean;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
+import org.springframework.data.hadoop.util.net.DefaultHostInfoDiscovery;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 import reactor.Environment;
@@ -63,7 +64,8 @@ public abstract class AbstractLoadTests {
 		@Bean
 		public ReadableTableFactoryBean greenplumReadableTable() {
 			ReadableTableFactoryBean factory = new ReadableTableFactoryBean();
-			factory.setLocations(Arrays.asList(NetworkUtils.getGPFDistUri(8080)));
+			DefaultHostInfoDiscovery discovery = new DefaultHostInfoDiscovery();
+			factory.setLocations(Arrays.asList(NetworkUtils.getGPFDistUri(discovery.getHostInfo().getAddress(), 8080)));
 			factory.setFormat(Format.TEXT);
 			return factory;
 		}

--- a/gpfdist-sink/src/test/java/org/springframework/cloud/stream/module/gpfdist/sink/HostInfoDiscoveryPropertiesTests.java
+++ b/gpfdist-sink/src/test/java/org/springframework/cloud/stream/module/gpfdist/sink/HostInfoDiscoveryPropertiesTests.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.stream.module.gpfdist.sink;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Configuration;
+
+public class HostInfoDiscoveryPropertiesTests {
+
+	@Test
+	public void testAllSet() {
+		SpringApplication app = new SpringApplication(TestConfiguration.class);
+		app.setWebEnvironment(false);
+		ConfigurableApplicationContext context = app
+				.run(new String[] { "--spring.net.hostdiscovery.pointToPoint=true",
+						"--spring.net.hostdiscovery.loopback=true",
+						"--spring.net.hostdiscovery.preferInterface=lxcbr",
+						"--spring.net.hostdiscovery.matchIpv4=192.168.0.0/24",
+						"--spring.net.hostdiscovery.matchInterface=eth0" });
+
+		HostInfoDiscoveryProperties properties = context.getBean(HostInfoDiscoveryProperties.class);
+		assertThat(properties, notNullValue());
+		assertThat(properties.isPointToPoint(), is(true));
+		assertThat(properties.isLoopback(), is(true));
+		assertThat(properties.getPreferInterface(), notNullValue());
+		assertThat(properties.getPreferInterface().size(), is(1));
+		assertThat(properties.getMatchIpv4(), is("192.168.0.0/24"));
+		assertThat(properties.getMatchInterface(), is("eth0"));
+		context.close();
+	}
+
+	@Test
+	public void testPreferOne() {
+		SpringApplication app = new SpringApplication(TestConfiguration.class);
+		app.setWebEnvironment(false);
+		ConfigurableApplicationContext context = app
+				.run(new String[] { "--spring.net.hostdiscovery.preferInterface=lxcbr" });
+
+		HostInfoDiscoveryProperties properties = context.getBean(HostInfoDiscoveryProperties.class);
+		assertThat(properties, notNullValue());
+		assertThat(properties.getPreferInterface(), notNullValue());
+		assertThat(properties.getPreferInterface().size(), is(1));
+		context.close();
+	}
+
+	@Test
+	public void testPreferTwo() {
+		SpringApplication app = new SpringApplication(TestConfiguration.class);
+		app.setWebEnvironment(false);
+		ConfigurableApplicationContext context = app
+				.run(new String[] { "--spring.net.hostdiscovery.preferInterface=lxcbr,foo" });
+
+		HostInfoDiscoveryProperties properties = context.getBean(HostInfoDiscoveryProperties.class);
+		assertThat(properties, notNullValue());
+		assertThat(properties.getPreferInterface(), notNullValue());
+		assertThat(properties.getPreferInterface().size(), is(2));
+		assertThat(properties.getPreferInterface(), containsInAnyOrder("lxcbr", "foo"));
+		context.close();
+	}
+
+	@Configuration
+	@EnableConfigurationProperties({ HostInfoDiscoveryProperties.class })
+	protected static class TestConfiguration {
+	}
+
+}


### PR DESCRIPTION
- Using host discovery from spring-data-hadoop-util.
- Need to exclude all hadoop deps as those are pulled
  in by spring-data-hadoop-util which adds servlet api for 2.5
  and boot breaks.
- Under `spring.net.hostdiscovery` we can use
  options `pointToPoint`, `loopback`, `preferInterface`,
  `matchIpv4` and `matchInterface` to set logic how correct
  address is discovered.
- Fixes #160 

To test(assuming gpdb running on `mdw`)

and table created:

```
gpadmin=# create table ticktock (date text, time text);
```

```
java -jar time-source/target/time-source-1.0.0.BUILD-SNAPSHOT-exec.jar --server.port=8081 --spring.cloud.stream.bindings.output=xxx
java -jar gpfdist-sink/target/gpfdist-sink-1.0.0.BUILD-SNAPSHOT-exec.jar --server.port=8082 --spring.cloud.stream.bindings.input=xxx --dbHost=mdw --table=ticktock --batchTime=1 --batchPeriod=1 --flushCount=2 --flushTime=2 --columnDelimiter=" " --spring.net.hostdiscovery.matchInterface=eth0
```

and play with options.

There's a short moment when external table exists:

```
gpadmin=# \d ticktock_ext_71e73035_656c_40bf_9ebd_6447166b8e58
External table "public.ticktock_ext_71e73035_656c_40bf_9ebd_6447166b8e58"
 Column | Type | Modifiers 
--------+------+-----------
 date   | text | 
 time   | text | 
Type: readable
Encoding: UTF8
Format type: text
Format options: delimiter ' ' null '\N' escape '\'
External location: gpfdist://10.0.3.1:44742/data
```
