### PR TITLE
Refactor `lang` -> `language`

### DIFF
--- a/scriptable-transform-processor/README.adoc
+++ b/scriptable-transform-processor/README.adoc
@@ -13,7 +13,7 @@ ScriptableTransformProcessorApplication:: the Spring Boot Main Application
 ScriptableTransformProcessor:: the actual module code that interacts with message channels
 ScriptableTransformProcessorProperties:: defines the configuration properties that are available to the Script Transform Processor
   * script: the textual form of the script to run
-  * lang: what language is the script? e.g. groovy/js/ruby
+  * language: what language is the script? e.g. groovy/js/ruby
   * variables: variable bindings as a comma delimited string of name-value pairs, e.g. 'foo=bar,baz=car'
   * variablesLocation: the location of a properties file containing custom script variable bindings
 
@@ -38,19 +38,19 @@ dataflow> module register --name scriptable --coordinates org.springframework.cl
 ## Using in a Spring Cloud Dataflow stream definition
 
 ```
-dataflow> stream create --deploy true --name demog --definition "time | scriptable --script=\"return payload+'::'+payload\" --lang=groovy | log"
+dataflow> stream create --deploy true --name demog --definition "time | scriptable --script=\"return payload+'::'+payload\" --language=groovy | log"
 ```
 
 ```
-dataflow> stream create --deploy true --name demor --definition "time | scriptable --script=\"return \"\"#{payload.upcase}\"\"\" --lang=ruby | log"
+dataflow> stream create --deploy true --name demor --definition "time | scriptable --script=\"return \"\"#{payload.upcase}\"\"\" --language=ruby | log"
 ```
 
 ```
-dataflow> stream create --deploy true --name demojs --definition "time | scriptable --script=\"function double(a) {\\n return a+''+a;\\n}\\ndouble(payload);\" --lang=js | log"
+dataflow> stream create --deploy true --name demojs --definition "time | scriptable --script=\"function double(a) {\\n return a+''+a;\\n}\\ndouble(payload);\" --language=js | log"
 ```
 
 Python is not currently working but when it does it will look like this!
 
 ```
-dataflow> stream create --deploy true --name demop --definition "time | scriptable --script=\"def concat(x,y):\\n  return x+y\\nanswer = concat(\"\"hello \"\",payload)\\n\" --lang=python | log"
+dataflow> stream create --deploy true --name demop --definition "time | scriptable --script=\"def concat(x,y):\\n  return x+y\\nanswer = concat(\"\"hello \"\",payload)\\n\" --language=python | log"
 ```

--- a/scriptable-transform-processor/src/main/java/org/springframework/cloud/stream/module/transform/ScriptableTransformProcessor.java
+++ b/scriptable-transform-processor/src/main/java/org/springframework/cloud/stream/module/transform/ScriptableTransformProcessor.java
@@ -64,7 +64,7 @@ public class ScriptableTransformProcessor {
 	@Bean
 	@Transformer(inputChannel = Processor.INPUT, outputChannel = Processor.OUTPUT)
 	public MessageProcessor<?> transformer() {
-		String language = this.properties.getLang();
+		String language = this.properties.getLanguage();
 		String script = this.properties.getScript();
 		logger.info("Input script is '{}', language is '{}'", script, language);
 		Resource scriptResource = new ByteArrayResource(decodeScript(script).getBytes()) {

--- a/scriptable-transform-processor/src/main/java/org/springframework/cloud/stream/module/transform/ScriptableTransformProcessorProperties.java
+++ b/scriptable-transform-processor/src/main/java/org/springframework/cloud/stream/module/transform/ScriptableTransformProcessorProperties.java
@@ -31,7 +31,7 @@ public class ScriptableTransformProcessorProperties {
 	 * Language of the text in the script property. Supported: groovy, javascript, ruby, python.
 	 */
 	@NotNull
-	private String lang;
+	private String language;
 
 	/*
 	 * Extra notes on the script parameter. The UI will typically look after encoding
@@ -53,16 +53,16 @@ public class ScriptableTransformProcessorProperties {
 	@NotNull
 	private String script;
 
-	public String getLang() {
-		return lang;
+	public String getLanguage() {
+		return this.language;
 	}
 
-	public void setLang(String lang) {
-		this.lang = lang;
+	public void setLanguage(String language) {
+		this.language = language;
 	}
 
 	public String getScript() {
-		return script;
+		return this.script;
 	}
 
 	public void setScript(String script) {

--- a/scriptable-transform-processor/src/test/java/org/springframework/cloud/stream/module/transform/ScriptableTransformProcessorIntegrationTests.java
+++ b/scriptable-transform-processor/src/test/java/org/springframework/cloud/stream/module/transform/ScriptableTransformProcessorIntegrationTests.java
@@ -51,7 +51,7 @@ public abstract class ScriptableTransformProcessorIntegrationTests {
 	@Autowired
 	protected MessageCollector collector;
 
-	@WebIntegrationTest({"script=function add(a,b) { return a+b;};add(1,3)", "lang=js"})
+	@WebIntegrationTest({"script=function add(a,b) { return a+b;};add(1,3)", "language=js"})
 	public static class JavascriptScriptProperty1Tests extends ScriptableTransformProcessorIntegrationTests {
 
 		@Test
@@ -61,7 +61,7 @@ public abstract class ScriptableTransformProcessorIntegrationTests {
 		}
 	}
 
-	@WebIntegrationTest({"script=payload+foo", "lang=js", "variables=foo=\\\\\40WORLD"})
+	@WebIntegrationTest({"script=payload+foo", "language=js", "variables=foo=\\\\\40WORLD"})
 	public static class JavascriptScriptProperty2Tests extends ScriptableTransformProcessorIntegrationTests {
 
 		@Test
@@ -72,7 +72,7 @@ public abstract class ScriptableTransformProcessorIntegrationTests {
 
 	}
 
-	@WebIntegrationTest({"script=payload*limit", "lang=js", "variables=limit=5"})
+	@WebIntegrationTest({"script=payload*limit", "language=js", "variables=limit=5"})
 	public static class JavascriptScriptProperty3Tests extends ScriptableTransformProcessorIntegrationTests {
 
 		@Test
@@ -83,7 +83,7 @@ public abstract class ScriptableTransformProcessorIntegrationTests {
 
 	}
 
-	@WebIntegrationTest({"script=payload+foo", "lang=groovy", "variables=foo=\\\\\40WORLD"})
+	@WebIntegrationTest({"script=payload+foo", "language=groovy", "variables=foo=\\\\\40WORLD"})
 	public static class GroovyScriptProperty1Tests extends ScriptableTransformProcessorIntegrationTests {
 
 		@Test
@@ -94,7 +94,7 @@ public abstract class ScriptableTransformProcessorIntegrationTests {
 
 	}
 
-	@WebIntegrationTest({"script=payload.substring(0, limit as int) + foo", "lang=groovy",
+	@WebIntegrationTest({"script=payload.substring(0, limit as int) + foo", "language=groovy",
 			"variables=limit=5\\n foo=\\\\\40WORLD"})
 	public static class GroovyScriptProperty2Tests extends ScriptableTransformProcessorIntegrationTests {
 
@@ -106,7 +106,7 @@ public abstract class ScriptableTransformProcessorIntegrationTests {
 
 	}
 
-	@WebIntegrationTest({"script=return \"\"#{payload.upcase}\"\"", "lang=ruby"})
+	@WebIntegrationTest({"script=return \"\"#{payload.upcase}\"\"", "language=ruby"})
 	public static class RubyScriptProperty1Tests extends ScriptableTransformProcessorIntegrationTests {
 
 		@Test
@@ -117,7 +117,7 @@ public abstract class ScriptableTransformProcessorIntegrationTests {
 
 	}
 
-	@WebIntegrationTest({"script=\"def foo(x)\\n  return x+5\\nend\\nfoo(payload)\\n\"", "lang=ruby"})
+	@WebIntegrationTest({"script=\"def foo(x)\\n  return x+5\\nend\\nfoo(payload)\\n\"", "language=ruby"})
 	public static class RubyScriptProperty2Tests extends ScriptableTransformProcessorIntegrationTests {
 
 		@Test
@@ -131,7 +131,7 @@ public abstract class ScriptableTransformProcessorIntegrationTests {
 	// Python not currently supported, problems running it in SCDF
 
 	@WebIntegrationTest({"script=\"def multiply(x,y):\\n  return x*y\\nanswer = multiply(payload,5)\\n\"",
-			"lang=python"})
+			"language=python"})
 	public static class PythonScriptProperty1Tests extends ScriptableTransformProcessorIntegrationTests {
 
 		@Test
@@ -143,7 +143,7 @@ public abstract class ScriptableTransformProcessorIntegrationTests {
 	}
 
 	@WebIntegrationTest({"script=\"def concat(x,y):\\n  return x+y\\nanswer = concat(\"\"hello \"\",payload)\\n\"",
-			"lang=python"})
+			"language=python"})
 	public static class PythonScriptProperty2Tests extends ScriptableTransformProcessorIntegrationTests {
 
 		@Test

--- a/spring-cloud-stream-modules-docs/src/main/asciidoc/processors.adoc
+++ b/spring-cloud-stream-modules-docs/src/main/asciidoc/processors.adoc
@@ -83,13 +83,13 @@ The language of the script must be specified (groovy/javascript/ruby/python) wit
 The **$$scriptable-transform$$** $$processor$$ has the following options:
 
 $$script$$:: $$The script text$$ *($$String$$, default: ``)*
-lang:: $$The script language$$ *($$String$$, default: ``)*
+language:: $$The script language$$ *($$String$$, default: ``)*
 $$variables$$:: $$Variable bindings as a comma delimited string of name-value pairs, e.g. 'foo=bar,baz=car'$$ *($$String$$, default: ``)*
 $$variablesLocation$$:: $$The location of a properties file containing custom script variable bindings$$ *($$String$$, default: ``)*
 
 ==== Using in a Spring Cloud Dataflow stream definition
 ```
-dataflow> stream create --deploy true --name demog --definition "time | scriptable-transform --script=\"return payload+'::'+payload\" --lang=groovy | log"
+dataflow> stream create --deploy true --name demog --definition "time | scriptable-transform --script=\"return payload+'::'+payload\" --language=groovy | log"
 ```
 
 [[spring-cloud-stream-modules-transform]]


### PR DESCRIPTION
The `lang` name for application property isn't good enough and may clash with ENV var or System property.
Change the property to the `language` back.

The future story with the global common prefix for apps should fix similar confuse.
