### PR TITLE
Add `jsonpath` as dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,11 @@
 				<scope>test</scope>
 			</dependency>
 			<dependency>
+				<groupId>com.jayway.jsonpath</groupId>
+				<artifactId>json-path</artifactId>
+				<version>2.2.0</version>
+			</dependency>
+			<dependency>
 				<groupId>org.springframework.cloud.stream.module</groupId>
 				<artifactId>script-variable-generator</artifactId>
 				<version>1.0.0.BUILD-SNAPSHOT</version>


### PR DESCRIPTION
Without the dependency, when using `jsonpath` in `--expression` property, I get the following error.

```
2016-04-13T12:19:33.29-0700 [APP/0]      OUT Caused by: org.springframework.expression.spel.SpelEvaluationException: EL1022E:(pos 0): The function 'jsonPath' mapped to an object of type 'class org.springframework.expression.TypedValue' which cannot be invoked
```

With this change, I can interact with the payload as: 

```
stream create --name filterTest --definition "http | transform --expression=\"#jsonPath(payload,'$._output')\" | log" --deploy
```

This is applicable for any application that supports `--expression` property; hence, it is included in the root `pom`.

_note: this change needs ported over to app-starter eventually; the assembly mechanism is different there since we do not have a root-level `pom`_
