### PR TITLE
Replace spring-cloud-stream-parent as main parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,8 @@
 	</organization>
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
-		<artifactId>spring-cloud-stream-parent</artifactId>
-		<version>1.0.0.BUILD-SNAPSHOT</version>
+		<artifactId>spring-cloud-build</artifactId>
+		<version>1.1.0.RC1</version>
 		<relativePath />
 	</parent>
 
@@ -90,10 +90,31 @@
 					<classifier>exec</classifier>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<configuration>
+					<quiet>true</quiet>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<redirectTestOutputToFile>true</redirectTestOutputToFile>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 	<dependencyManagement>
 		<dependencies>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-stream-dependencies</artifactId>
+				<version>${spring-cloud-stream.version}</version>
+				<scope>import</scope>
+				<type>pom</type>
+			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud.stream.module</groupId>
 				<artifactId>spring-cloud-stream-modules-dependencies</artifactId>


### PR DESCRIPTION
Fixes #252

Set `spring-cloud-build` as parent
Add `spring-cloud-stream-dependencies` as a dependencies BOM
Copy plugin configurations from the former parent, so that the current behaviour is preserved
