### PR TITLE
URL Cleanup

### DIFF
--- a/aggregate-counter-sink/src/main/java/org/springframework/cloud/stream/module/metrics/AggregateCounterSink.java
+++ b/aggregate-counter-sink/src/main/java/org/springframework/cloud/stream/module/metrics/AggregateCounterSink.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/aggregate-counter-sink/src/main/java/org/springframework/cloud/stream/module/metrics/AggregateCounterSinkApplication.java
+++ b/aggregate-counter-sink/src/main/java/org/springframework/cloud/stream/module/metrics/AggregateCounterSinkApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/aggregate-counter-sink/src/main/java/org/springframework/cloud/stream/module/metrics/AggregateCounterSinkProperties.java
+++ b/aggregate-counter-sink/src/main/java/org/springframework/cloud/stream/module/metrics/AggregateCounterSinkProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/aggregate-counter-sink/src/main/java/org/springframework/cloud/stream/module/metrics/AggregateCounterSinkStoreConfiguration.java
+++ b/aggregate-counter-sink/src/main/java/org/springframework/cloud/stream/module/metrics/AggregateCounterSinkStoreConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/aggregate-counter-sink/src/test/java/org/springframework/cloud/stream/module/AggregateCounterTests.java
+++ b/aggregate-counter-sink/src/test/java/org/springframework/cloud/stream/module/AggregateCounterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/bridge-processor/src/main/java/org/springframework/cloud/stream/module/bridge/BridgeProcessor.java
+++ b/bridge-processor/src/main/java/org/springframework/cloud/stream/module/bridge/BridgeProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/bridge-processor/src/main/java/org/springframework/cloud/stream/module/bridge/BridgeProcessorApplication.java
+++ b/bridge-processor/src/main/java/org/springframework/cloud/stream/module/bridge/BridgeProcessorApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/bridge-processor/src/test/java/org/springframework/cloud/stream/module/bridge/BridgeProcessorIntegrationTests.java
+++ b/bridge-processor/src/test/java/org/springframework/cloud/stream/module/bridge/BridgeProcessorIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/cassandra-sink/src/main/java/org/springframework/cloud/stream/module/cassandra/CassandraConfiguration.java
+++ b/cassandra-sink/src/main/java/org/springframework/cloud/stream/module/cassandra/CassandraConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/cassandra-sink/src/main/java/org/springframework/cloud/stream/module/cassandra/CassandraProperties.java
+++ b/cassandra-sink/src/main/java/org/springframework/cloud/stream/module/cassandra/CassandraProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/cassandra-sink/src/main/java/org/springframework/cloud/stream/module/cassandra/sink/CassandraSinkApplication.java
+++ b/cassandra-sink/src/main/java/org/springframework/cloud/stream/module/cassandra/sink/CassandraSinkApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/cassandra-sink/src/main/java/org/springframework/cloud/stream/module/cassandra/sink/CassandraSinkConfiguration.java
+++ b/cassandra-sink/src/main/java/org/springframework/cloud/stream/module/cassandra/sink/CassandraSinkConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/cassandra-sink/src/main/java/org/springframework/cloud/stream/module/cassandra/sink/CassandraSinkProperties.java
+++ b/cassandra-sink/src/main/java/org/springframework/cloud/stream/module/cassandra/sink/CassandraSinkProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/cassandra-sink/src/test/java/org/springframework/cloud/stream/module/cassandra/sink/CassandraSinkIntegrationTests.java
+++ b/cassandra-sink/src/test/java/org/springframework/cloud/stream/module/cassandra/sink/CassandraSinkIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/cassandra-sink/src/test/java/org/springframework/cloud/stream/module/cassandra/sink/CassandraSinkPropertiesTests.java
+++ b/cassandra-sink/src/test/java/org/springframework/cloud/stream/module/cassandra/sink/CassandraSinkPropertiesTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/cassandra-sink/src/test/java/org/springframework/cloud/stream/module/cassandra/test/domain/Book.java
+++ b/cassandra-sink/src/test/java/org/springframework/cloud/stream/module/cassandra/test/domain/Book.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/script-variable-generator/src/main/java/org/springframework/cloud/stream/module/common/ScriptVariableGeneratorConfiguration.java
+++ b/common/script-variable-generator/src/main/java/org/springframework/cloud/stream/module/common/ScriptVariableGeneratorConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/script-variable-generator/src/main/java/org/springframework/cloud/stream/module/common/ScriptVariableProperties.java
+++ b/common/script-variable-generator/src/main/java/org/springframework/cloud/stream/module/common/ScriptVariableProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-analytics/src/main/java/org/springframework/cloud/stream/module/metrics/AggregateCounter.java
+++ b/common/spring-cloud-stream-modules-analytics/src/main/java/org/springframework/cloud/stream/module/metrics/AggregateCounter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-analytics/src/main/java/org/springframework/cloud/stream/module/metrics/AggregateCounterReader.java
+++ b/common/spring-cloud-stream-modules-analytics/src/main/java/org/springframework/cloud/stream/module/metrics/AggregateCounterReader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-analytics/src/main/java/org/springframework/cloud/stream/module/metrics/AggregateCounterRepository.java
+++ b/common/spring-cloud-stream-modules-analytics/src/main/java/org/springframework/cloud/stream/module/metrics/AggregateCounterRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-analytics/src/main/java/org/springframework/cloud/stream/module/metrics/AggregateCounterResolution.java
+++ b/common/spring-cloud-stream-modules-analytics/src/main/java/org/springframework/cloud/stream/module/metrics/AggregateCounterResolution.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-analytics/src/main/java/org/springframework/cloud/stream/module/metrics/AggregateCounterWriter.java
+++ b/common/spring-cloud-stream-modules-analytics/src/main/java/org/springframework/cloud/stream/module/metrics/AggregateCounterWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-analytics/src/main/java/org/springframework/cloud/stream/module/metrics/FieldValueCounter.java
+++ b/common/spring-cloud-stream-modules-analytics/src/main/java/org/springframework/cloud/stream/module/metrics/FieldValueCounter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-analytics/src/main/java/org/springframework/cloud/stream/module/metrics/FieldValueCounterReader.java
+++ b/common/spring-cloud-stream-modules-analytics/src/main/java/org/springframework/cloud/stream/module/metrics/FieldValueCounterReader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-analytics/src/main/java/org/springframework/cloud/stream/module/metrics/FieldValueCounterRepository.java
+++ b/common/spring-cloud-stream-modules-analytics/src/main/java/org/springframework/cloud/stream/module/metrics/FieldValueCounterRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-analytics/src/main/java/org/springframework/cloud/stream/module/metrics/FieldValueCounterWriter.java
+++ b/common/spring-cloud-stream-modules-analytics/src/main/java/org/springframework/cloud/stream/module/metrics/FieldValueCounterWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-analytics/src/main/java/org/springframework/cloud/stream/module/metrics/MetricUtils.java
+++ b/common/spring-cloud-stream-modules-analytics/src/main/java/org/springframework/cloud/stream/module/metrics/MetricUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-analytics/src/main/java/org/springframework/cloud/stream/module/metrics/memory/InMemoryAggregateCounter.java
+++ b/common/spring-cloud-stream-modules-analytics/src/main/java/org/springframework/cloud/stream/module/metrics/memory/InMemoryAggregateCounter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-analytics/src/main/java/org/springframework/cloud/stream/module/metrics/memory/InMemoryAggregateCounterRepository.java
+++ b/common/spring-cloud-stream-modules-analytics/src/main/java/org/springframework/cloud/stream/module/metrics/memory/InMemoryAggregateCounterRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-analytics/src/main/java/org/springframework/cloud/stream/module/metrics/memory/InMemoryFieldValueCounterRepository.java
+++ b/common/spring-cloud-stream-modules-analytics/src/main/java/org/springframework/cloud/stream/module/metrics/memory/InMemoryFieldValueCounterRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-analytics/src/main/java/org/springframework/cloud/stream/module/metrics/redis/AggregateKeyGenerator.java
+++ b/common/spring-cloud-stream-modules-analytics/src/main/java/org/springframework/cloud/stream/module/metrics/redis/AggregateKeyGenerator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-analytics/src/main/java/org/springframework/cloud/stream/module/metrics/redis/RedisAggregateCounterRepository.java
+++ b/common/spring-cloud-stream-modules-analytics/src/main/java/org/springframework/cloud/stream/module/metrics/redis/RedisAggregateCounterRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-analytics/src/main/java/org/springframework/cloud/stream/module/metrics/redis/RedisFieldValueCounterRepository.java
+++ b/common/spring-cloud-stream-modules-analytics/src/main/java/org/springframework/cloud/stream/module/metrics/redis/RedisFieldValueCounterRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-analytics/src/main/java/org/springframework/cloud/stream/module/retry/LoggingRecoveryCallback.java
+++ b/common/spring-cloud-stream-modules-analytics/src/main/java/org/springframework/cloud/stream/module/retry/LoggingRecoveryCallback.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-analytics/src/main/java/org/springframework/cloud/stream/module/retry/RedisRetryTemplate.java
+++ b/common/spring-cloud-stream-modules-analytics/src/main/java/org/springframework/cloud/stream/module/retry/RedisRetryTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-analytics/src/main/java/org/springframework/cloud/stream/module/retry/StringRedisRetryTemplate.java
+++ b/common/spring-cloud-stream-modules-analytics/src/main/java/org/springframework/cloud/stream/module/retry/StringRedisRetryTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/DateFormat.java
+++ b/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/DateFormat.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/MaxMessagesProperties.java
+++ b/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/MaxMessagesProperties.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/SourcePayloadProperties.java
+++ b/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/SourcePayloadProperties.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/annotation/PollableSource.java
+++ b/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/annotation/PollableSource.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/file/FileConsumerProperties.java
+++ b/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/file/FileConsumerProperties.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/file/FileReadingMode.java
+++ b/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/file/FileReadingMode.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/file/FileUtils.java
+++ b/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/file/FileUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/file/remote/AbstractRemoteFileProperties.java
+++ b/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/file/remote/AbstractRemoteFileProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/file/remote/AbstractRemoteFileSinkProperties.java
+++ b/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/file/remote/AbstractRemoteFileSinkProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/file/remote/AbstractRemoteFileSourceProperties.java
+++ b/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/file/remote/AbstractRemoteFileSourceProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/file/remote/AbstractRemoteServerProperties.java
+++ b/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/file/remote/AbstractRemoteServerProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/ftp/FtpSessionFactoryConfiguration.java
+++ b/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/ftp/FtpSessionFactoryConfiguration.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/ftp/FtpSessionFactoryProperties.java
+++ b/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/ftp/FtpSessionFactoryProperties.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/gemfire/GemfireClientRegionConfiguration.java
+++ b/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/gemfire/GemfireClientRegionConfiguration.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/gemfire/GemfirePoolConfiguration.java
+++ b/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/gemfire/GemfirePoolConfiguration.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/gemfire/GemfirePoolProperties.java
+++ b/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/gemfire/GemfirePoolProperties.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/gemfire/GemfireRegionProperties.java
+++ b/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/gemfire/GemfireRegionProperties.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/gemfire/InetSocketAddressConverterConfiguration.java
+++ b/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/gemfire/InetSocketAddressConverterConfiguration.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/metrics/MetricProperties.java
+++ b/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/metrics/MetricProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/sftp/SftpSessionFactoryConfiguration.java
+++ b/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/sftp/SftpSessionFactoryConfiguration.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/sftp/SftpSessionFactoryProperties.java
+++ b/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/sftp/SftpSessionFactoryProperties.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/tcp/AbstractTcpConnectionFactoryProperties.java
+++ b/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/tcp/AbstractTcpConnectionFactoryProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/tcp/EncoderDecoderFactoryBean.java
+++ b/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/tcp/EncoderDecoderFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/trigger/DateTrigger.java
+++ b/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/trigger/DateTrigger.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/trigger/TriggerConfiguration.java
+++ b/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/trigger/TriggerConfiguration.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/trigger/TriggerConstants.java
+++ b/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/trigger/TriggerConstants.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/trigger/TriggerProperties.java
+++ b/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/trigger/TriggerProperties.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/twitter/TwitterCredentials.java
+++ b/common/spring-cloud-stream-modules-common-configuration/src/main/java/org/springframework/cloud/stream/module/twitter/TwitterCredentials.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-common-configuration/src/test/java/org/springframework/cloud/stream/module/PeriodicTriggerPropertiesTests.java
+++ b/common/spring-cloud-stream-modules-common-configuration/src/test/java/org/springframework/cloud/stream/module/PeriodicTriggerPropertiesTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-common-configuration/src/test/java/org/springframework/cloud/stream/module/file/FileConsumerPropertiesTests.java
+++ b/common/spring-cloud-stream-modules-common-configuration/src/test/java/org/springframework/cloud/stream/module/file/FileConsumerPropertiesTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-common-configuration/src/test/java/org/springframework/cloud/stream/module/ftp/FtpSessionFactoryPropertiesTests.java
+++ b/common/spring-cloud-stream-modules-common-configuration/src/test/java/org/springframework/cloud/stream/module/ftp/FtpSessionFactoryPropertiesTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-common-configuration/src/test/java/org/springframework/cloud/stream/module/gemfire/GemfireClientRegionConfigurationTests.java
+++ b/common/spring-cloud-stream-modules-common-configuration/src/test/java/org/springframework/cloud/stream/module/gemfire/GemfireClientRegionConfigurationTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-common-configuration/src/test/java/org/springframework/cloud/stream/module/gemfire/GemfirePoolPropertiesTests.java
+++ b/common/spring-cloud-stream-modules-common-configuration/src/test/java/org/springframework/cloud/stream/module/gemfire/GemfirePoolPropertiesTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-common-configuration/src/test/java/org/springframework/cloud/stream/module/sftp/SftpSessionFactoryPropertiesTests.java
+++ b/common/spring-cloud-stream-modules-common-configuration/src/test/java/org/springframework/cloud/stream/module/sftp/SftpSessionFactoryPropertiesTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-test-support/src/main/java/org/springframework/cloud/stream/modules/test/PropertiesInitializer.java
+++ b/common/spring-cloud-stream-modules-test-support/src/main/java/org/springframework/cloud/stream/modules/test/PropertiesInitializer.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-test-support/src/main/java/org/springframework/cloud/stream/modules/test/file/remote/FtpTestSupport.java
+++ b/common/spring-cloud-stream-modules-test-support/src/main/java/org/springframework/cloud/stream/modules/test/file/remote/FtpTestSupport.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-test-support/src/main/java/org/springframework/cloud/stream/modules/test/file/remote/RemoteFileTestSupport.java
+++ b/common/spring-cloud-stream-modules-test-support/src/main/java/org/springframework/cloud/stream/modules/test/file/remote/RemoteFileTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-test-support/src/main/java/org/springframework/cloud/stream/modules/test/file/remote/SftpTestSupport.java
+++ b/common/spring-cloud-stream-modules-test-support/src/main/java/org/springframework/cloud/stream/modules/test/file/remote/SftpTestSupport.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-test-support/src/main/java/org/springframework/cloud/stream/modules/test/gemfire/process/ProcessConfiguration.java
+++ b/common/spring-cloud-stream-modules-test-support/src/main/java/org/springframework/cloud/stream/modules/test/gemfire/process/ProcessConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-test-support/src/main/java/org/springframework/cloud/stream/modules/test/gemfire/process/ProcessExecutor.java
+++ b/common/spring-cloud-stream-modules-test-support/src/main/java/org/springframework/cloud/stream/modules/test/gemfire/process/ProcessExecutor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-test-support/src/main/java/org/springframework/cloud/stream/modules/test/gemfire/process/ProcessInputStreamListener.java
+++ b/common/spring-cloud-stream-modules-test-support/src/main/java/org/springframework/cloud/stream/modules/test/gemfire/process/ProcessInputStreamListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-test-support/src/main/java/org/springframework/cloud/stream/modules/test/gemfire/process/ProcessWrapper.java
+++ b/common/spring-cloud-stream-modules-test-support/src/main/java/org/springframework/cloud/stream/modules/test/gemfire/process/ProcessWrapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-test-support/src/main/java/org/springframework/cloud/stream/modules/test/gemfire/process/ServerProcess.java
+++ b/common/spring-cloud-stream-modules-test-support/src/main/java/org/springframework/cloud/stream/modules/test/gemfire/process/ServerProcess.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-test-support/src/main/java/org/springframework/cloud/stream/modules/test/gemfire/process/support/PidUnavailableException.java
+++ b/common/spring-cloud-stream-modules-test-support/src/main/java/org/springframework/cloud/stream/modules/test/gemfire/process/support/PidUnavailableException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-test-support/src/main/java/org/springframework/cloud/stream/modules/test/gemfire/process/support/ProcessUtils.java
+++ b/common/spring-cloud-stream-modules-test-support/src/main/java/org/springframework/cloud/stream/modules/test/gemfire/process/support/ProcessUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-test-support/src/main/java/org/springframework/cloud/stream/modules/test/gemfire/support/FileSystemUtils.java
+++ b/common/spring-cloud-stream-modules-test-support/src/main/java/org/springframework/cloud/stream/modules/test/gemfire/support/FileSystemUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-test-support/src/main/java/org/springframework/cloud/stream/modules/test/gemfire/support/IOUtils.java
+++ b/common/spring-cloud-stream-modules-test-support/src/main/java/org/springframework/cloud/stream/modules/test/gemfire/support/IOUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-test-support/src/main/java/org/springframework/cloud/stream/modules/test/gemfire/support/ThreadUtils.java
+++ b/common/spring-cloud-stream-modules-test-support/src/main/java/org/springframework/cloud/stream/modules/test/gemfire/support/ThreadUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-test-support/src/main/java/org/springframework/cloud/stream/modules/test/gemfire/support/ThrowableUtils.java
+++ b/common/spring-cloud-stream-modules-test-support/src/main/java/org/springframework/cloud/stream/modules/test/gemfire/support/ThrowableUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-stream-modules-test-support/src/main/java/org/springframework/cloud/stream/modules/test/hamcrest/HamcrestMatchers.java
+++ b/common/spring-cloud-stream-modules-test-support/src/main/java/org/springframework/cloud/stream/modules/test/hamcrest/HamcrestMatchers.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/counter-sink/src/main/java/org/springframework/cloud/stream/module/metrics/CounterProperties.java
+++ b/counter-sink/src/main/java/org/springframework/cloud/stream/module/metrics/CounterProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/counter-sink/src/main/java/org/springframework/cloud/stream/module/metrics/CounterSink.java
+++ b/counter-sink/src/main/java/org/springframework/cloud/stream/module/metrics/CounterSink.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/counter-sink/src/main/java/org/springframework/cloud/stream/module/metrics/CounterSinkApplication.java
+++ b/counter-sink/src/main/java/org/springframework/cloud/stream/module/metrics/CounterSinkApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/counter-sink/src/main/java/org/springframework/cloud/stream/module/metrics/CounterSinkStoreConfiguration.java
+++ b/counter-sink/src/main/java/org/springframework/cloud/stream/module/metrics/CounterSinkStoreConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/counter-sink/src/test/java/org/springframework/cloud/stream/module/metrics/AbstractCounterSinkTests.java
+++ b/counter-sink/src/test/java/org/springframework/cloud/stream/module/metrics/AbstractCounterSinkTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/counter-sink/src/test/java/org/springframework/cloud/stream/module/metrics/CounterSinkDefaultNameTests.java
+++ b/counter-sink/src/test/java/org/springframework/cloud/stream/module/metrics/CounterSinkDefaultNameTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/counter-sink/src/test/java/org/springframework/cloud/stream/module/metrics/CounterSinkExpressionNameTests.java
+++ b/counter-sink/src/test/java/org/springframework/cloud/stream/module/metrics/CounterSinkExpressionNameTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/counter-sink/src/test/java/org/springframework/cloud/stream/module/metrics/CounterSinkNameTests.java
+++ b/counter-sink/src/test/java/org/springframework/cloud/stream/module/metrics/CounterSinkNameTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/field-value-counter-sink/src/main/java/org/springframework/cloud/stream/module/metrics/FieldValueCounterSink.java
+++ b/field-value-counter-sink/src/main/java/org/springframework/cloud/stream/module/metrics/FieldValueCounterSink.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/field-value-counter-sink/src/main/java/org/springframework/cloud/stream/module/metrics/FieldValueCounterSinkApplication.java
+++ b/field-value-counter-sink/src/main/java/org/springframework/cloud/stream/module/metrics/FieldValueCounterSinkApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/field-value-counter-sink/src/main/java/org/springframework/cloud/stream/module/metrics/FieldValueCounterSinkProperties.java
+++ b/field-value-counter-sink/src/main/java/org/springframework/cloud/stream/module/metrics/FieldValueCounterSinkProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/field-value-counter-sink/src/main/java/org/springframework/cloud/stream/module/metrics/FieldValueCounterSinkStoreConfiguration.java
+++ b/field-value-counter-sink/src/main/java/org/springframework/cloud/stream/module/metrics/FieldValueCounterSinkStoreConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/field-value-counter-sink/src/test/java/org/springframework/cloud/stream/module/metrics/FieldValueCounterSinkTests.java
+++ b/field-value-counter-sink/src/test/java/org/springframework/cloud/stream/module/metrics/FieldValueCounterSinkTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/field-value-counter-sink/src/test/java/org/springframework/cloud/stream/module/metrics/FieldValueCounterSinkWithDefaultsTests.java
+++ b/field-value-counter-sink/src/test/java/org/springframework/cloud/stream/module/metrics/FieldValueCounterSinkWithDefaultsTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/file-sink/src/main/java/org/springframework/cloud/stream/module/file/sink/FileSinkApplication.java
+++ b/file-sink/src/main/java/org/springframework/cloud/stream/module/file/sink/FileSinkApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/file-sink/src/main/java/org/springframework/cloud/stream/module/file/sink/FileSinkConfiguration.java
+++ b/file-sink/src/main/java/org/springframework/cloud/stream/module/file/sink/FileSinkConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/file-sink/src/main/java/org/springframework/cloud/stream/module/file/sink/FileSinkProperties.java
+++ b/file-sink/src/main/java/org/springframework/cloud/stream/module/file/sink/FileSinkProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/file-sink/src/test/java/org/springframework/cloud/stream/module/file/sink/FileSinkTests.java
+++ b/file-sink/src/test/java/org/springframework/cloud/stream/module/file/sink/FileSinkTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/file-source/src/main/java/org/springframework/cloud/stream/module/file/source/FileSource.java
+++ b/file-source/src/main/java/org/springframework/cloud/stream/module/file/source/FileSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/file-source/src/main/java/org/springframework/cloud/stream/module/file/source/FileSourceApplication.java
+++ b/file-source/src/main/java/org/springframework/cloud/stream/module/file/source/FileSourceApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/file-source/src/main/java/org/springframework/cloud/stream/module/file/source/FileSourceProperties.java
+++ b/file-source/src/main/java/org/springframework/cloud/stream/module/file/source/FileSourceProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/file-source/src/test/java/org/springframework/cloud/stream/module/file/source/FileSourceTests.java
+++ b/file-source/src/test/java/org/springframework/cloud/stream/module/file/source/FileSourceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/filter-processor/src/main/java/org/springframework/cloud/stream/module/filter/FilterProcessor.java
+++ b/filter-processor/src/main/java/org/springframework/cloud/stream/module/filter/FilterProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/filter-processor/src/main/java/org/springframework/cloud/stream/module/filter/FilterProcessorApplication.java
+++ b/filter-processor/src/main/java/org/springframework/cloud/stream/module/filter/FilterProcessorApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/filter-processor/src/main/java/org/springframework/cloud/stream/module/filter/FilterProcessorProperties.java
+++ b/filter-processor/src/main/java/org/springframework/cloud/stream/module/filter/FilterProcessorProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/filter-processor/src/test/java/org/springframework/cloud/stream/module/filter/FilterProcessorIntegrationTests.java
+++ b/filter-processor/src/test/java/org/springframework/cloud/stream/module/filter/FilterProcessorIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ftp-sink/src/main/java/org/springframework/cloud/stream/module/ftp/FtpSink.java
+++ b/ftp-sink/src/main/java/org/springframework/cloud/stream/module/ftp/FtpSink.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ftp-sink/src/main/java/org/springframework/cloud/stream/module/ftp/FtpSinkApplication.java
+++ b/ftp-sink/src/main/java/org/springframework/cloud/stream/module/ftp/FtpSinkApplication.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ftp-sink/src/main/java/org/springframework/cloud/stream/module/ftp/FtpSinkProperties.java
+++ b/ftp-sink/src/main/java/org/springframework/cloud/stream/module/ftp/FtpSinkProperties.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ftp-sink/src/test/java/org/springframework/cloud/stream/module/ftp/FtpSinkIntegrationTests.java
+++ b/ftp-sink/src/test/java/org/springframework/cloud/stream/module/ftp/FtpSinkIntegrationTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ftp-sink/src/test/java/org/springframework/cloud/stream/module/ftp/FtpSinkPropertiesTests.java
+++ b/ftp-sink/src/test/java/org/springframework/cloud/stream/module/ftp/FtpSinkPropertiesTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ftp-source/src/main/java/org/springframework/cloud/stream/module/ftp/source/FtpSource.java
+++ b/ftp-source/src/main/java/org/springframework/cloud/stream/module/ftp/source/FtpSource.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ftp-source/src/main/java/org/springframework/cloud/stream/module/ftp/source/FtpSourceApplication.java
+++ b/ftp-source/src/main/java/org/springframework/cloud/stream/module/ftp/source/FtpSourceApplication.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ftp-source/src/main/java/org/springframework/cloud/stream/module/ftp/source/FtpSourceProperties.java
+++ b/ftp-source/src/main/java/org/springframework/cloud/stream/module/ftp/source/FtpSourceProperties.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ftp-source/src/test/java/org/springframework/cloud/stream/module/ftp/source/FtpSourceIntegrationTests.java
+++ b/ftp-source/src/test/java/org/springframework/cloud/stream/module/ftp/source/FtpSourceIntegrationTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ftp-source/src/test/java/org/springframework/cloud/stream/module/ftp/source/FtpSourcePropertiesTests.java
+++ b/ftp-source/src/test/java/org/springframework/cloud/stream/module/ftp/source/FtpSourcePropertiesTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gemfire-sink/src/main/java/org/springframework/cloud/stream/module/gemfire/GemfireSink.java
+++ b/gemfire-sink/src/main/java/org/springframework/cloud/stream/module/gemfire/GemfireSink.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gemfire-sink/src/main/java/org/springframework/cloud/stream/module/gemfire/GemfireSinkApplication.java
+++ b/gemfire-sink/src/main/java/org/springframework/cloud/stream/module/gemfire/GemfireSinkApplication.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gemfire-sink/src/main/java/org/springframework/cloud/stream/module/gemfire/GemfireSinkProperties.java
+++ b/gemfire-sink/src/main/java/org/springframework/cloud/stream/module/gemfire/GemfireSinkProperties.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gemfire-sink/src/test/java/org/springframework/cloud/stream/module/gemfire/GemfireSinkIntegrationTests.java
+++ b/gemfire-sink/src/test/java/org/springframework/cloud/stream/module/gemfire/GemfireSinkIntegrationTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gemfire-sink/src/test/java/org/springframework/cloud/stream/module/gemfire/GemfireSinkPropertiesTests.java
+++ b/gemfire-sink/src/test/java/org/springframework/cloud/stream/module/gemfire/GemfireSinkPropertiesTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/AbstractGpfdistMessageHandler.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/AbstractGpfdistMessageHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/GpfdistCodec.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/GpfdistCodec.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/GpfdistConfiguration.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/GpfdistConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/GpfdistMessageHandler.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/GpfdistMessageHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/GpfdistServer.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/GpfdistServer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/GpfdistSinkApplication.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/GpfdistSinkApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/GpfdistSinkProperties.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/GpfdistSinkProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/HostInfoDiscoveryProperties.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/HostInfoDiscoveryProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/AbstractExternalTable.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/AbstractExternalTable.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/ControlFile.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/ControlFile.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/ControlFileFactoryBean.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/ControlFileFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/DefaultGreenplumLoad.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/DefaultGreenplumLoad.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/DefaultLoadService.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/DefaultLoadService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/Format.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/Format.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/GreenplumDataSourceFactoryBean.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/GreenplumDataSourceFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/GreenplumLoad.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/GreenplumLoad.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/JdbcCommands.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/JdbcCommands.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/LoadConfiguration.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/LoadConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/LoadConfigurationFactoryBean.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/LoadConfigurationFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/LoadFactoryBean.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/LoadFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/LoadService.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/LoadService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/Mode.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/Mode.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/NetworkUtils.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/NetworkUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/ReadableTable.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/ReadableTable.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/ReadableTableFactoryBean.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/ReadableTableFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/RuntimeContext.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/RuntimeContext.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/SegmentRejectType.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/SegmentRejectType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/SqlUtils.java
+++ b/gpfdist-sink/src/main/java/org/springframework/cloud/stream/module/gpfdist/sink/support/SqlUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist-sink/src/test/java/org/springframework/cloud/stream/module/gpfdist/sink/AbstractDbTests.java
+++ b/gpfdist-sink/src/test/java/org/springframework/cloud/stream/module/gpfdist/sink/AbstractDbTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist-sink/src/test/java/org/springframework/cloud/stream/module/gpfdist/sink/AbstractLoadTests.java
+++ b/gpfdist-sink/src/test/java/org/springframework/cloud/stream/module/gpfdist/sink/AbstractLoadTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist-sink/src/test/java/org/springframework/cloud/stream/module/gpfdist/sink/GpfdistSinkPropertiesTests.java
+++ b/gpfdist-sink/src/test/java/org/springframework/cloud/stream/module/gpfdist/sink/GpfdistSinkPropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist-sink/src/test/java/org/springframework/cloud/stream/module/gpfdist/sink/HostInfoDiscoveryPropertiesTests.java
+++ b/gpfdist-sink/src/test/java/org/springframework/cloud/stream/module/gpfdist/sink/HostInfoDiscoveryPropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist-sink/src/test/java/org/springframework/cloud/stream/module/gpfdist/sink/LoadIT.java
+++ b/gpfdist-sink/src/test/java/org/springframework/cloud/stream/module/gpfdist/sink/LoadIT.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist-sink/src/test/java/org/springframework/cloud/stream/module/gpfdist/sink/TestListenAddress.java
+++ b/gpfdist-sink/src/test/java/org/springframework/cloud/stream/module/gpfdist/sink/TestListenAddress.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist-sink/src/test/java/org/springframework/cloud/stream/module/gpfdist/sink/TestUtils.java
+++ b/gpfdist-sink/src/test/java/org/springframework/cloud/stream/module/gpfdist/sink/TestUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist-sink/src/test/java/org/springframework/cloud/stream/module/gpfdist/sink/support/ControlFileTests.java
+++ b/gpfdist-sink/src/test/java/org/springframework/cloud/stream/module/gpfdist/sink/support/ControlFileTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist-sink/src/test/java/org/springframework/cloud/stream/module/gpfdist/sink/support/LoadConfigurationFactoryBeanTests.java
+++ b/gpfdist-sink/src/test/java/org/springframework/cloud/stream/module/gpfdist/sink/support/LoadConfigurationFactoryBeanTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gpfdist-sink/src/test/java/org/springframework/cloud/stream/module/gpfdist/sink/support/LoadConfigurationIT.java
+++ b/gpfdist-sink/src/test/java/org/springframework/cloud/stream/module/gpfdist/sink/support/LoadConfigurationIT.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/groovy-filter-processor/src/main/java/org/springframework/cloud/stream/module/filter/GroovyFilterProcessor.java
+++ b/groovy-filter-processor/src/main/java/org/springframework/cloud/stream/module/filter/GroovyFilterProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/groovy-filter-processor/src/main/java/org/springframework/cloud/stream/module/filter/GroovyFilterProcessorApplication.java
+++ b/groovy-filter-processor/src/main/java/org/springframework/cloud/stream/module/filter/GroovyFilterProcessorApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/groovy-filter-processor/src/main/java/org/springframework/cloud/stream/module/filter/GroovyFilterProcessorProperties.java
+++ b/groovy-filter-processor/src/main/java/org/springframework/cloud/stream/module/filter/GroovyFilterProcessorProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/groovy-filter-processor/src/test/java/org/springframework/cloud/stream/module/filter/GroovyFilterProcessorApplicationIntegrationTests.java
+++ b/groovy-filter-processor/src/test/java/org/springframework/cloud/stream/module/filter/GroovyFilterProcessorApplicationIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/groovy-filter-processor/src/test/resources/script.groovy
+++ b/groovy-filter-processor/src/test/resources/script.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/groovy-transform-processor/src/main/java/org/springframework/cloud/stream/module/transform/GroovyTransformProcessor.java
+++ b/groovy-transform-processor/src/main/java/org/springframework/cloud/stream/module/transform/GroovyTransformProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/groovy-transform-processor/src/main/java/org/springframework/cloud/stream/module/transform/GroovyTransformProcessorApplication.java
+++ b/groovy-transform-processor/src/main/java/org/springframework/cloud/stream/module/transform/GroovyTransformProcessorApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/groovy-transform-processor/src/main/java/org/springframework/cloud/stream/module/transform/GroovyTransformProcessorProperties.java
+++ b/groovy-transform-processor/src/main/java/org/springframework/cloud/stream/module/transform/GroovyTransformProcessorProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/groovy-transform-processor/src/test/java/org/springframework/cloud/stream/module/transform/GroovyTransformProcessorIntegrationTests.java
+++ b/groovy-transform-processor/src/test/java/org/springframework/cloud/stream/module/transform/GroovyTransformProcessorIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/hdfs-dataset-sink/src/main/java/org/springframework/cloud/stream/module/dataset/sink/DatasetSinkApplication.java
+++ b/hdfs-dataset-sink/src/main/java/org/springframework/cloud/stream/module/dataset/sink/DatasetSinkApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/hdfs-dataset-sink/src/main/java/org/springframework/cloud/stream/module/dataset/sink/DatasetSinkConfiguration.java
+++ b/hdfs-dataset-sink/src/main/java/org/springframework/cloud/stream/module/dataset/sink/DatasetSinkConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/hdfs-dataset-sink/src/main/java/org/springframework/cloud/stream/module/dataset/sink/DatasetSinkProperties.java
+++ b/hdfs-dataset-sink/src/main/java/org/springframework/cloud/stream/module/dataset/sink/DatasetSinkProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/hdfs-dataset-sink/src/test/java/org/springframework/cloud/stream/module/dataset/domain/TestPojo.java
+++ b/hdfs-dataset-sink/src/test/java/org/springframework/cloud/stream/module/dataset/domain/TestPojo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/hdfs-dataset-sink/src/test/java/org/springframework/cloud/stream/module/dataset/sink/DatasetSinkIntegrationTests.java
+++ b/hdfs-dataset-sink/src/test/java/org/springframework/cloud/stream/module/dataset/sink/DatasetSinkIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/hdfs-dataset-sink/src/test/java/org/springframework/cloud/stream/module/dataset/sink/DatasetSinkPropertiesTests.java
+++ b/hdfs-dataset-sink/src/test/java/org/springframework/cloud/stream/module/dataset/sink/DatasetSinkPropertiesTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/hdfs-sink/src/main/java/org/springframework/cloud/stream/module/hdfs/sink/DataStoreWriterFactoryBean.java
+++ b/hdfs-sink/src/main/java/org/springframework/cloud/stream/module/hdfs/sink/DataStoreWriterFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/hdfs-sink/src/main/java/org/springframework/cloud/stream/module/hdfs/sink/HdfsSink.java
+++ b/hdfs-sink/src/main/java/org/springframework/cloud/stream/module/hdfs/sink/HdfsSink.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/hdfs-sink/src/main/java/org/springframework/cloud/stream/module/hdfs/sink/HdfsSinkApplication.java
+++ b/hdfs-sink/src/main/java/org/springframework/cloud/stream/module/hdfs/sink/HdfsSinkApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/hdfs-sink/src/main/java/org/springframework/cloud/stream/module/hdfs/sink/HdfsSinkConfiguration.java
+++ b/hdfs-sink/src/main/java/org/springframework/cloud/stream/module/hdfs/sink/HdfsSinkConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/hdfs-sink/src/main/java/org/springframework/cloud/stream/module/hdfs/sink/HdfsSinkProperties.java
+++ b/hdfs-sink/src/main/java/org/springframework/cloud/stream/module/hdfs/sink/HdfsSinkProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/hdfs-sink/src/test/java/org/springframework/cloud/stream/module/hdfs/sink/HdfsSinkConfigurationTests.java
+++ b/hdfs-sink/src/test/java/org/springframework/cloud/stream/module/hdfs/sink/HdfsSinkConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/hdfs-sink/src/test/java/org/springframework/cloud/stream/module/hdfs/sink/HdfsSinkIntegrationTests.java
+++ b/hdfs-sink/src/test/java/org/springframework/cloud/stream/module/hdfs/sink/HdfsSinkIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/hdfs-sink/src/test/java/org/springframework/cloud/stream/module/hdfs/sink/HdfsSinkPropertiesTests.java
+++ b/hdfs-sink/src/test/java/org/springframework/cloud/stream/module/hdfs/sink/HdfsSinkPropertiesTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/http-source/src/main/java/org/springframework/cloud/stream/module/http/HttpSource.java
+++ b/http-source/src/main/java/org/springframework/cloud/stream/module/http/HttpSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/http-source/src/main/java/org/springframework/cloud/stream/module/http/HttpSourceApplication.java
+++ b/http-source/src/main/java/org/springframework/cloud/stream/module/http/HttpSourceApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/http-source/src/test/java/org/springframework/cloud/stream/module/http/HttpSourceTests.java
+++ b/http-source/src/test/java/org/springframework/cloud/stream/module/http/HttpSourceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/httpclient-processor/src/main/java/org/springframework/cloud/stream/module/httpclient/HttpClientProcessor.java
+++ b/httpclient-processor/src/main/java/org/springframework/cloud/stream/module/httpclient/HttpClientProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/httpclient-processor/src/main/java/org/springframework/cloud/stream/module/httpclient/HttpClientProcessorApplication.java
+++ b/httpclient-processor/src/main/java/org/springframework/cloud/stream/module/httpclient/HttpClientProcessorApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/httpclient-processor/src/main/java/org/springframework/cloud/stream/module/httpclient/HttpClientProcessorConfiguration.java
+++ b/httpclient-processor/src/main/java/org/springframework/cloud/stream/module/httpclient/HttpClientProcessorConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/httpclient-processor/src/main/java/org/springframework/cloud/stream/module/httpclient/HttpClientProcessorProperties.java
+++ b/httpclient-processor/src/main/java/org/springframework/cloud/stream/module/httpclient/HttpClientProcessorProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/httpclient-processor/src/test/java/org/springframework/cloud/stream/module/httpclient/HttpClientProcessorTests.java
+++ b/httpclient-processor/src/test/java/org/springframework/cloud/stream/module/httpclient/HttpClientProcessorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test-processor/src/main/java/org/springframework/cloud/stream/module/it/IntegrationTestProcessor.java
+++ b/integration-test-processor/src/main/java/org/springframework/cloud/stream/module/it/IntegrationTestProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test-processor/src/main/java/org/springframework/cloud/stream/module/it/IntegrationTestProcessorApplication.java
+++ b/integration-test-processor/src/main/java/org/springframework/cloud/stream/module/it/IntegrationTestProcessorApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test-processor/src/main/java/org/springframework/cloud/stream/module/it/IntegrationTestProcessorProperties.java
+++ b/integration-test-processor/src/main/java/org/springframework/cloud/stream/module/it/IntegrationTestProcessorProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/jdbc-sink/src/main/java/org/springframework/cloud/stream/module/jdbc/DefaultInitializationScriptResource.java
+++ b/jdbc-sink/src/main/java/org/springframework/cloud/stream/module/jdbc/DefaultInitializationScriptResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/jdbc-sink/src/main/java/org/springframework/cloud/stream/module/jdbc/JdbcSinkApplication.java
+++ b/jdbc-sink/src/main/java/org/springframework/cloud/stream/module/jdbc/JdbcSinkApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/jdbc-sink/src/main/java/org/springframework/cloud/stream/module/jdbc/JdbcSinkConfiguration.java
+++ b/jdbc-sink/src/main/java/org/springframework/cloud/stream/module/jdbc/JdbcSinkConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/jdbc-sink/src/main/java/org/springframework/cloud/stream/module/jdbc/JdbcSinkProperties.java
+++ b/jdbc-sink/src/main/java/org/springframework/cloud/stream/module/jdbc/JdbcSinkProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/jdbc-sink/src/main/java/org/springframework/cloud/stream/module/jdbc/ShorthandMapConverter.java
+++ b/jdbc-sink/src/main/java/org/springframework/cloud/stream/module/jdbc/ShorthandMapConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/jdbc-sink/src/main/java/org/springframework/cloud/stream/module/jdbc/SupportsShorthands.java
+++ b/jdbc-sink/src/main/java/org/springframework/cloud/stream/module/jdbc/SupportsShorthands.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/jdbc-sink/src/test/java/org/springframework/cloud/stream/module/jdbc/JdbcSinkIntegrationTests.java
+++ b/jdbc-sink/src/test/java/org/springframework/cloud/stream/module/jdbc/JdbcSinkIntegrationTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/jdbc-sink/src/test/java/org/springframework/cloud/stream/module/jdbc/ShorthandMapConverterTests.java
+++ b/jdbc-sink/src/test/java/org/springframework/cloud/stream/module/jdbc/ShorthandMapConverterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/jdbc-source/src/main/java/org/springframework/cloud/stream/module/jdbc/source/JdbcSourceApplication.java
+++ b/jdbc-source/src/main/java/org/springframework/cloud/stream/module/jdbc/source/JdbcSourceApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/jdbc-source/src/main/java/org/springframework/cloud/stream/module/jdbc/source/JdbcSourceConfiguration.java
+++ b/jdbc-source/src/main/java/org/springframework/cloud/stream/module/jdbc/source/JdbcSourceConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/jdbc-source/src/main/java/org/springframework/cloud/stream/module/jdbc/source/JdbcSourceProperties.java
+++ b/jdbc-source/src/main/java/org/springframework/cloud/stream/module/jdbc/source/JdbcSourceProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/jdbc-source/src/test/java/org/springframework/cloud/stream/module/jdbc/source/JdbcSourceIntegrationTests.java
+++ b/jdbc-source/src/test/java/org/springframework/cloud/stream/module/jdbc/source/JdbcSourceIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/jdbc-source/src/test/java/org/springframework/cloud/stream/module/jdbc/source/JdbcSourcePropertiesTests.java
+++ b/jdbc-source/src/test/java/org/springframework/cloud/stream/module/jdbc/source/JdbcSourcePropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/jms-source/src/main/java/org/springframework/cloud/stream/module/jms/source/JmsSource.java
+++ b/jms-source/src/main/java/org/springframework/cloud/stream/module/jms/source/JmsSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/jms-source/src/main/java/org/springframework/cloud/stream/module/jms/source/JmsSourceApplication.java
+++ b/jms-source/src/main/java/org/springframework/cloud/stream/module/jms/source/JmsSourceApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/jms-source/src/main/java/org/springframework/cloud/stream/module/jms/source/JmsSourceProperties.java
+++ b/jms-source/src/main/java/org/springframework/cloud/stream/module/jms/source/JmsSourceProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/jms-source/src/test/java/org/springframework/cloud/stream/module/jms/source/JmsSourceTests.java
+++ b/jms-source/src/test/java/org/springframework/cloud/stream/module/jms/source/JmsSourceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/load-generator-source/src/main/java/org/springframework/cloud/stream/module/loadgenerator/LoadGeneratorSource.java
+++ b/load-generator-source/src/main/java/org/springframework/cloud/stream/module/loadgenerator/LoadGeneratorSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/load-generator-source/src/main/java/org/springframework/cloud/stream/module/loadgenerator/LoadGeneratorSourceApplication.java
+++ b/load-generator-source/src/main/java/org/springframework/cloud/stream/module/loadgenerator/LoadGeneratorSourceApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/load-generator-source/src/main/java/org/springframework/cloud/stream/module/loadgenerator/LoadGeneratorSourceProperties.java
+++ b/load-generator-source/src/main/java/org/springframework/cloud/stream/module/loadgenerator/LoadGeneratorSourceProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/load-generator-source/src/test/java/org/springframework/cloud/stream/module/http/LoadGeneratorSourceTests.java
+++ b/load-generator-source/src/test/java/org/springframework/cloud/stream/module/http/LoadGeneratorSourceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/log-sink/src/main/java/org/springframework/cloud/stream/module/log/LogSink.java
+++ b/log-sink/src/main/java/org/springframework/cloud/stream/module/log/LogSink.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/log-sink/src/main/java/org/springframework/cloud/stream/module/log/LogSinkApplication.java
+++ b/log-sink/src/main/java/org/springframework/cloud/stream/module/log/LogSinkApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/log-sink/src/main/java/org/springframework/cloud/stream/module/log/LogSinkProperties.java
+++ b/log-sink/src/main/java/org/springframework/cloud/stream/module/log/LogSinkProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/log-sink/src/test/java/org/springframework/cloud/stream/module/log/LogSinkApplicationTests.java
+++ b/log-sink/src/test/java/org/springframework/cloud/stream/module/log/LogSinkApplicationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/loggregator-source/src/main/java/org/springframework/cloud/stream/module/loggregator/source/LoggregatorMessageSource.java
+++ b/loggregator-source/src/main/java/org/springframework/cloud/stream/module/loggregator/source/LoggregatorMessageSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/loggregator-source/src/main/java/org/springframework/cloud/stream/module/loggregator/source/LoggregatorProperties.java
+++ b/loggregator-source/src/main/java/org/springframework/cloud/stream/module/loggregator/source/LoggregatorProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/loggregator-source/src/main/java/org/springframework/cloud/stream/module/loggregator/source/LoggregatorSource.java
+++ b/loggregator-source/src/main/java/org/springframework/cloud/stream/module/loggregator/source/LoggregatorSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/loggregator-source/src/main/java/org/springframework/cloud/stream/module/loggregator/source/LoggregatorSourceApplication.java
+++ b/loggregator-source/src/main/java/org/springframework/cloud/stream/module/loggregator/source/LoggregatorSourceApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/loggregator-source/src/test/java/org/springframework/cloud/stream/module/loggregator/source/LoggregatorSourceTest.java
+++ b/loggregator-source/src/test/java/org/springframework/cloud/stream/module/loggregator/source/LoggregatorSourceTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/pmml-processor/src/main/java/org/springframework/cloud/stream/module/pmml/processor/CustomConversionServiceRegistrar.java
+++ b/pmml-processor/src/main/java/org/springframework/cloud/stream/module/pmml/processor/CustomConversionServiceRegistrar.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/pmml-processor/src/main/java/org/springframework/cloud/stream/module/pmml/processor/GenericMapConverter.java
+++ b/pmml-processor/src/main/java/org/springframework/cloud/stream/module/pmml/processor/GenericMapConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/pmml-processor/src/main/java/org/springframework/cloud/stream/module/pmml/processor/PmmlProcessor.java
+++ b/pmml-processor/src/main/java/org/springframework/cloud/stream/module/pmml/processor/PmmlProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/pmml-processor/src/main/java/org/springframework/cloud/stream/module/pmml/processor/PmmlProcessorApplication.java
+++ b/pmml-processor/src/main/java/org/springframework/cloud/stream/module/pmml/processor/PmmlProcessorApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/pmml-processor/src/main/java/org/springframework/cloud/stream/module/pmml/processor/PmmlProcessorProperties.java
+++ b/pmml-processor/src/main/java/org/springframework/cloud/stream/module/pmml/processor/PmmlProcessorProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/pmml-processor/src/test/java/org/springframework/cloud/stream/module/pmml/processor/GenericMapConverterTests.java
+++ b/pmml-processor/src/test/java/org/springframework/cloud/stream/module/pmml/processor/GenericMapConverterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/pmml-processor/src/test/java/org/springframework/cloud/stream/module/pmml/processor/PmmlProcessorIntegrationTests.java
+++ b/pmml-processor/src/test/java/org/springframework/cloud/stream/module/pmml/processor/PmmlProcessorIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/rabbit-sink/src/main/java/org/springframework/cloud/stream/module/rabbit/sink/RabbitSink.java
+++ b/rabbit-sink/src/main/java/org/springframework/cloud/stream/module/rabbit/sink/RabbitSink.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/rabbit-sink/src/main/java/org/springframework/cloud/stream/module/rabbit/sink/RabbitSinkApplication.java
+++ b/rabbit-sink/src/main/java/org/springframework/cloud/stream/module/rabbit/sink/RabbitSinkApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/rabbit-sink/src/main/java/org/springframework/cloud/stream/module/rabbit/sink/RabbitSinkProperties.java
+++ b/rabbit-sink/src/main/java/org/springframework/cloud/stream/module/rabbit/sink/RabbitSinkProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/rabbit-sink/src/test/java/org/springframework/cloud/stream/module/rabbit/sink/RabbitSinkInvalidConfigTests.java
+++ b/rabbit-sink/src/test/java/org/springframework/cloud/stream/module/rabbit/sink/RabbitSinkInvalidConfigTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/rabbit-sink/src/test/java/org/springframework/cloud/stream/module/rabbit/sink/RabbitSinkTests.java
+++ b/rabbit-sink/src/test/java/org/springframework/cloud/stream/module/rabbit/sink/RabbitSinkTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/rabbit-source/src/main/java/org/springframework/cloud/stream/module/rabbit/source/RabbitSource.java
+++ b/rabbit-source/src/main/java/org/springframework/cloud/stream/module/rabbit/source/RabbitSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/rabbit-source/src/main/java/org/springframework/cloud/stream/module/rabbit/source/RabbitSourceApplication.java
+++ b/rabbit-source/src/main/java/org/springframework/cloud/stream/module/rabbit/source/RabbitSourceApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/rabbit-source/src/main/java/org/springframework/cloud/stream/module/rabbit/source/RabbitSourceProperties.java
+++ b/rabbit-source/src/main/java/org/springframework/cloud/stream/module/rabbit/source/RabbitSourceProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/rabbit-source/src/test/java/org/springframework/cloud/stream/module/rabbit/source/RabbitSourceInvalidConfigTests.java
+++ b/rabbit-source/src/test/java/org/springframework/cloud/stream/module/rabbit/source/RabbitSourceInvalidConfigTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/rabbit-source/src/test/java/org/springframework/cloud/stream/module/rabbit/source/RabbitSourceTests.java
+++ b/rabbit-source/src/test/java/org/springframework/cloud/stream/module/rabbit/source/RabbitSourceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/redis-sink/src/main/java/org/springframework/cloud/stream/module/redis/sink/RedisSink.java
+++ b/redis-sink/src/main/java/org/springframework/cloud/stream/module/redis/sink/RedisSink.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/redis-sink/src/main/java/org/springframework/cloud/stream/module/redis/sink/RedisSinkApplication.java
+++ b/redis-sink/src/main/java/org/springframework/cloud/stream/module/redis/sink/RedisSinkApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/redis-sink/src/test/java/org/springframework/cloud/stream/module/redis/sink/RedisSinkApplicationTests.java
+++ b/redis-sink/src/test/java/org/springframework/cloud/stream/module/redis/sink/RedisSinkApplicationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/router-sink/src/main/java/org/springframework/cloud/stream/module/router/sink/RouterSink.java
+++ b/router-sink/src/main/java/org/springframework/cloud/stream/module/router/sink/RouterSink.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/router-sink/src/main/java/org/springframework/cloud/stream/module/router/sink/RouterSinkApplication.java
+++ b/router-sink/src/main/java/org/springframework/cloud/stream/module/router/sink/RouterSinkApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/router-sink/src/main/java/org/springframework/cloud/stream/module/router/sink/RouterSinkProperties.java
+++ b/router-sink/src/main/java/org/springframework/cloud/stream/module/router/sink/RouterSinkProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/router-sink/src/test/java/org/springframework/cloud/stream/module/router/sink/RouterSinkTests.java
+++ b/router-sink/src/test/java/org/springframework/cloud/stream/module/router/sink/RouterSinkTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scriptable-transform-processor/src/main/java/org/springframework/cloud/stream/module/transform/ScriptableTransformProcessor.java
+++ b/scriptable-transform-processor/src/main/java/org/springframework/cloud/stream/module/transform/ScriptableTransformProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scriptable-transform-processor/src/main/java/org/springframework/cloud/stream/module/transform/ScriptableTransformProcessorApplication.java
+++ b/scriptable-transform-processor/src/main/java/org/springframework/cloud/stream/module/transform/ScriptableTransformProcessorApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scriptable-transform-processor/src/main/java/org/springframework/cloud/stream/module/transform/ScriptableTransformProcessorProperties.java
+++ b/scriptable-transform-processor/src/main/java/org/springframework/cloud/stream/module/transform/ScriptableTransformProcessorProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scriptable-transform-processor/src/test/java/org/springframework/cloud/stream/module/transform/ScriptableTransformProcessorIntegrationTests.java
+++ b/scriptable-transform-processor/src/test/java/org/springframework/cloud/stream/module/transform/ScriptableTransformProcessorIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sftp-source/src/main/java/org/springframework/cloud/stream/module/sftp/source/SftpSource.java
+++ b/sftp-source/src/main/java/org/springframework/cloud/stream/module/sftp/source/SftpSource.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sftp-source/src/main/java/org/springframework/cloud/stream/module/sftp/source/SftpSourceApplication.java
+++ b/sftp-source/src/main/java/org/springframework/cloud/stream/module/sftp/source/SftpSourceApplication.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sftp-source/src/main/java/org/springframework/cloud/stream/module/sftp/source/SftpSourceProperties.java
+++ b/sftp-source/src/main/java/org/springframework/cloud/stream/module/sftp/source/SftpSourceProperties.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sftp-source/src/test/java/org/springframework/cloud/stream/module/sftp/source/SftpSourceIntegrationTests.java
+++ b/sftp-source/src/test/java/org/springframework/cloud/stream/module/sftp/source/SftpSourceIntegrationTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sftp-source/src/test/java/org/springframework/cloud/stream/module/sftp/source/SftpSourcePropertiesTests.java
+++ b/sftp-source/src/test/java/org/springframework/cloud/stream/module/sftp/source/SftpSourcePropertiesTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/splitter-processor/src/main/java/org/springframework/cloud/stream/module/splitter/SplitterProcessor.java
+++ b/splitter-processor/src/main/java/org/springframework/cloud/stream/module/splitter/SplitterProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/splitter-processor/src/main/java/org/springframework/cloud/stream/module/splitter/SplitterProcessorApplication.java
+++ b/splitter-processor/src/main/java/org/springframework/cloud/stream/module/splitter/SplitterProcessorApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/splitter-processor/src/main/java/org/springframework/cloud/stream/module/splitter/SplitterProcessorProperties.java
+++ b/splitter-processor/src/main/java/org/springframework/cloud/stream/module/splitter/SplitterProcessorProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/splitter-processor/src/test/java/org/springframework/cloud/stream/module/splitter/SplitterProcessorIntegrationTests.java
+++ b/splitter-processor/src/test/java/org/springframework/cloud/stream/module/splitter/SplitterProcessorIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-modules-docs/src/main/docbook/xsl/common.xsl
+++ b/spring-cloud-stream-modules-docs/src/main/docbook/xsl/common.xsl
@@ -9,7 +9,7 @@
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+   https://www.apache.org/licenses/LICENSE-2.0
 
  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an

--- a/spring-cloud-stream-modules-docs/src/main/docbook/xsl/epub.xsl
+++ b/spring-cloud-stream-modules-docs/src/main/docbook/xsl/epub.xsl
@@ -9,7 +9,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/spring-cloud-stream-modules-docs/src/main/docbook/xsl/html-multipage.xsl
+++ b/spring-cloud-stream-modules-docs/src/main/docbook/xsl/html-multipage.xsl
@@ -9,7 +9,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/spring-cloud-stream-modules-docs/src/main/docbook/xsl/html-singlepage.xsl
+++ b/spring-cloud-stream-modules-docs/src/main/docbook/xsl/html-singlepage.xsl
@@ -9,7 +9,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/spring-cloud-stream-modules-docs/src/main/docbook/xsl/html.xsl
+++ b/spring-cloud-stream-modules-docs/src/main/docbook/xsl/html.xsl
@@ -9,7 +9,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/spring-cloud-stream-modules-docs/src/main/docbook/xsl/pdf.xsl
+++ b/spring-cloud-stream-modules-docs/src/main/docbook/xsl/pdf.xsl
@@ -9,7 +9,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/syslog-source/src/main/java/org/springframework/cloud/stream/module/syslog/source/SyslogSource.java
+++ b/syslog-source/src/main/java/org/springframework/cloud/stream/module/syslog/source/SyslogSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/syslog-source/src/main/java/org/springframework/cloud/stream/module/syslog/source/SyslogSourceApplication.java
+++ b/syslog-source/src/main/java/org/springframework/cloud/stream/module/syslog/source/SyslogSourceApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/syslog-source/src/main/java/org/springframework/cloud/stream/module/syslog/source/SyslogSourceProperties.java
+++ b/syslog-source/src/main/java/org/springframework/cloud/stream/module/syslog/source/SyslogSourceProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/syslog-source/src/test/java/org/springframework/cloud/stream/module/syslog/source/SyslogSourceTests.java
+++ b/syslog-source/src/test/java/org/springframework/cloud/stream/module/syslog/source/SyslogSourceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tcp-sink/src/main/java/org/springframework/cloud/stream/module/tcp/sink/TcpSink.java
+++ b/tcp-sink/src/main/java/org/springframework/cloud/stream/module/tcp/sink/TcpSink.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tcp-sink/src/main/java/org/springframework/cloud/stream/module/tcp/sink/TcpSinkApplication.java
+++ b/tcp-sink/src/main/java/org/springframework/cloud/stream/module/tcp/sink/TcpSinkApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tcp-sink/src/main/java/org/springframework/cloud/stream/module/tcp/sink/TcpSinkProperties.java
+++ b/tcp-sink/src/main/java/org/springframework/cloud/stream/module/tcp/sink/TcpSinkProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tcp-sink/src/test/java/org/springframework/cloud/stream/module/tcp/sink/TcpSinkTests.java
+++ b/tcp-sink/src/test/java/org/springframework/cloud/stream/module/tcp/sink/TcpSinkTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tcp-source/src/main/java/org/springframework/cloud/stream/module/tcp/source/TcpSource.java
+++ b/tcp-source/src/main/java/org/springframework/cloud/stream/module/tcp/source/TcpSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tcp-source/src/main/java/org/springframework/cloud/stream/module/tcp/source/TcpSourceApplication.java
+++ b/tcp-source/src/main/java/org/springframework/cloud/stream/module/tcp/source/TcpSourceApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tcp-source/src/main/java/org/springframework/cloud/stream/module/tcp/source/TcpSourceProperties.java
+++ b/tcp-source/src/main/java/org/springframework/cloud/stream/module/tcp/source/TcpSourceProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tcp-source/src/test/java/org/springframework/cloud/stream/module/tcp/source/TcpSourceTests.java
+++ b/tcp-source/src/test/java/org/springframework/cloud/stream/module/tcp/source/TcpSourceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/throughput-sink/src/main/java/org/springframework/cloud/stream/module/throughput/ThroughputSink.java
+++ b/throughput-sink/src/main/java/org/springframework/cloud/stream/module/throughput/ThroughputSink.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/throughput-sink/src/main/java/org/springframework/cloud/stream/module/throughput/ThroughputSinkApplication.java
+++ b/throughput-sink/src/main/java/org/springframework/cloud/stream/module/throughput/ThroughputSinkApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/throughput-sink/src/main/java/org/springframework/cloud/stream/module/throughput/ThroughputSinkProperties.java
+++ b/throughput-sink/src/main/java/org/springframework/cloud/stream/module/throughput/ThroughputSinkProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/throughput-sink/src/test/java/org/springframework/cloud/stream/module/throughput/ThroughputSinkApplicationTests.java
+++ b/throughput-sink/src/test/java/org/springframework/cloud/stream/module/throughput/ThroughputSinkApplicationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/time-source/src/main/java/org/springframework/cloud/stream/module/time/TimeSource.java
+++ b/time-source/src/main/java/org/springframework/cloud/stream/module/time/TimeSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/time-source/src/main/java/org/springframework/cloud/stream/module/time/TimeSourceApplication.java
+++ b/time-source/src/main/java/org/springframework/cloud/stream/module/time/TimeSourceApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/time-source/src/main/java/org/springframework/cloud/stream/module/time/TimeSourceProperties.java
+++ b/time-source/src/main/java/org/springframework/cloud/stream/module/time/TimeSourceProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/time-source/src/test/java/org/springframework/cloud/stream/module/time/TimeSourceIntegrationTests.java
+++ b/time-source/src/test/java/org/springframework/cloud/stream/module/time/TimeSourceIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/transform-processor/src/main/java/org/springframework/cloud/stream/module/transform/TransformProcessor.java
+++ b/transform-processor/src/main/java/org/springframework/cloud/stream/module/transform/TransformProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/transform-processor/src/main/java/org/springframework/cloud/stream/module/transform/TransformProcessorApplication.java
+++ b/transform-processor/src/main/java/org/springframework/cloud/stream/module/transform/TransformProcessorApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/transform-processor/src/main/java/org/springframework/cloud/stream/module/transform/TransformProcessorProperties.java
+++ b/transform-processor/src/main/java/org/springframework/cloud/stream/module/transform/TransformProcessorProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/transform-processor/src/test/java/org/springframework/cloud/stream/module/transform/TransformProcessorIntegrationTests.java
+++ b/transform-processor/src/test/java/org/springframework/cloud/stream/module/transform/TransformProcessorIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trigger-source/src/main/java/org/springframework/cloud/stream/module/trigger/TriggerSource.java
+++ b/trigger-source/src/main/java/org/springframework/cloud/stream/module/trigger/TriggerSource.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trigger-source/src/main/java/org/springframework/cloud/stream/module/trigger/TriggerSourceApplication.java
+++ b/trigger-source/src/main/java/org/springframework/cloud/stream/module/trigger/TriggerSourceApplication.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trigger-source/src/test/java/org/springframework/cloud/stream/module/trigger/TriggerSourceTests.java
+++ b/trigger-source/src/test/java/org/springframework/cloud/stream/module/trigger/TriggerSourceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/twitterstream-source/src/main/java/org/springframework/cloud/stream/module/twitter/AbstractTwitterInboundChannelAdapter.java
+++ b/twitterstream-source/src/main/java/org/springframework/cloud/stream/module/twitter/AbstractTwitterInboundChannelAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/twitterstream-source/src/main/java/org/springframework/cloud/stream/module/twitter/TwitterStreamApplication.java
+++ b/twitterstream-source/src/main/java/org/springframework/cloud/stream/module/twitter/TwitterStreamApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/twitterstream-source/src/main/java/org/springframework/cloud/stream/module/twitter/TwitterStreamMessageProducer.java
+++ b/twitterstream-source/src/main/java/org/springframework/cloud/stream/module/twitter/TwitterStreamMessageProducer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/twitterstream-source/src/main/java/org/springframework/cloud/stream/module/twitter/TwitterStreamProperties.java
+++ b/twitterstream-source/src/main/java/org/springframework/cloud/stream/module/twitter/TwitterStreamProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/twitterstream-source/src/main/java/org/springframework/cloud/stream/module/twitter/TwitterStreamSource.java
+++ b/twitterstream-source/src/main/java/org/springframework/cloud/stream/module/twitter/TwitterStreamSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/twitterstream-source/src/main/java/org/springframework/cloud/stream/module/twitter/TwitterStreamType.java
+++ b/twitterstream-source/src/main/java/org/springframework/cloud/stream/module/twitter/TwitterStreamType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/websocket-sink/src/main/java/org/springframework/cloud/stream/module/websocket/sink/WebsocketSink.java
+++ b/websocket-sink/src/main/java/org/springframework/cloud/stream/module/websocket/sink/WebsocketSink.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/websocket-sink/src/main/java/org/springframework/cloud/stream/module/websocket/sink/WebsocketSinkApplication.java
+++ b/websocket-sink/src/main/java/org/springframework/cloud/stream/module/websocket/sink/WebsocketSinkApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/websocket-sink/src/main/java/org/springframework/cloud/stream/module/websocket/sink/WebsocketSinkConfiguration.java
+++ b/websocket-sink/src/main/java/org/springframework/cloud/stream/module/websocket/sink/WebsocketSinkConfiguration.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/websocket-sink/src/main/java/org/springframework/cloud/stream/module/websocket/sink/WebsocketSinkProperties.java
+++ b/websocket-sink/src/main/java/org/springframework/cloud/stream/module/websocket/sink/WebsocketSinkProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/websocket-sink/src/main/java/org/springframework/cloud/stream/module/websocket/sink/WebsocketSinkServer.java
+++ b/websocket-sink/src/main/java/org/springframework/cloud/stream/module/websocket/sink/WebsocketSinkServer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/websocket-sink/src/main/java/org/springframework/cloud/stream/module/websocket/sink/WebsocketSinkServerHandler.java
+++ b/websocket-sink/src/main/java/org/springframework/cloud/stream/module/websocket/sink/WebsocketSinkServerHandler.java
@@ -5,7 +5,7 @@
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/websocket-sink/src/main/java/org/springframework/cloud/stream/module/websocket/sink/WebsocketSinkServerInitializer.java
+++ b/websocket-sink/src/main/java/org/springframework/cloud/stream/module/websocket/sink/WebsocketSinkServerInitializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/websocket-sink/src/main/java/org/springframework/cloud/stream/module/websocket/sink/actuator/WebsocketSinkTraceEndpoint.java
+++ b/websocket-sink/src/main/java/org/springframework/cloud/stream/module/websocket/sink/actuator/WebsocketSinkTraceEndpoint.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/websocket-sink/src/main/resources/static/index.html
+++ b/websocket-sink/src/main/resources/static/index.html
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/websocket-sink/src/test/java/org/springframework/cloud/stream/module/websocket/sink/WebsocketSinkIntegrationTests.java
+++ b/websocket-sink/src/test/java/org/springframework/cloud/stream/module/websocket/sink/WebsocketSinkIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 316 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).